### PR TITLE
[FIX] Sanitize title in using HTML attributes in <TabbedView />

### DIFF
--- a/components/TabbedView/TabbedView.jsx
+++ b/components/TabbedView/TabbedView.jsx
@@ -101,6 +101,13 @@ class TabbedView extends React.Component {
     this.setState({ activeTab: tab });
   };
 
+  sanitize = str =>
+    str
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(' ', '-')
+      .toLowerCase();
+
   render() {
     const { children, skin } = this.props;
     const { activeTab } = this.state;
@@ -113,8 +120,8 @@ class TabbedView extends React.Component {
               key={title}
               onClick={() => this.onTabClick(title)}
               skin={skin}
-              id={`${title}-tab`}
-              aria-controls={`${title}-panel`}
+              id={`${this.sanitize(title)}-tab`}
+              aria-controls={`${this.sanitize(title)}-panel`}
               aria-selected={title === activeTab}
             >
               {title}
@@ -128,8 +135,8 @@ class TabbedView extends React.Component {
             <RenderIf conditional={title === activeTab}>
               <div
                 role="tabpanel"
-                id={`${title}-panel`}
-                aria-labelledby={`${title}-tab`}
+                id={`${this.sanitize(title)}-panel`}
+                aria-labelledby={`${this.sanitize(title)}-tab`}
               >
                 {tabContent}
               </div>

--- a/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
+++ b/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
@@ -371,6 +371,7 @@ ShallowWrapper {
           "getChildContext": Object {
             "calledByRenderer": false,
           },
+          "getDerivedStateFromError": true,
           "getDerivedStateFromProps": Object {
             "hasShouldComponentUpdateBug": false,
           },


### PR DESCRIPTION
When there are title with accents and space in `<Tab />`, they're set in attributes in the elements.

![Screenshot from 2019-05-02 15-43-13](https://user-images.githubusercontent.com/190265/57098673-0e0a8780-6cf1-11e9-9dc4-7edfa8dda92b.png)

This pull request removes spaces and accents. It will replace space with "-" too.
