### PR TITLE
Fix/card title ie

### DIFF
--- a/components/Card/__snapshots__/Card.unit.test.jsx.snap
+++ b/components/Card/__snapshots__/Card.unit.test.jsx.snap
@@ -22,9 +22,7 @@ exports[`<Card /> Snapshots Should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  max-width: 100%;
-  display: inline-block;
-  word-break: break-all;
+  width: 100%;
 }
 
 .c3 {

--- a/components/Card/__snapshots__/Card.unit.test.jsx.snap
+++ b/components/Card/__snapshots__/Card.unit.test.jsx.snap
@@ -22,9 +22,9 @@ exports[`<Card /> Snapshots Should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  overflow: hidden;
   max-width: 100%;
   display: inline-block;
+  word-break: break-all;
 }
 
 .c3 {

--- a/components/Card/__snapshots__/Card.unit.test.jsx.snap
+++ b/components/Card/__snapshots__/Card.unit.test.jsx.snap
@@ -22,6 +22,9 @@ exports[`<Card /> Snapshots Should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  overflow: hidden;
+  max-width: 100%;
+  display: inline-block;
 }
 
 .c3 {

--- a/components/Card/sub-components/HeaderText.jsx
+++ b/components/Card/sub-components/HeaderText.jsx
@@ -2,6 +2,9 @@ import styled from 'styled-components';
 
 const HeaderText = styled.div`
   flex-grow: 1;
+  max-width: 100%;
+  display: inline-block;
+  word-break: break-all;
 `;
 
 HeaderText.displayName = 'Card.HeaderText';

--- a/components/Card/sub-components/HeaderText.jsx
+++ b/components/Card/sub-components/HeaderText.jsx
@@ -2,9 +2,7 @@ import styled from 'styled-components';
 
 const HeaderText = styled.div`
   flex-grow: 1;
-  max-width: 100%;
-  display: inline-block;
-  word-break: break-all;
+  width: 100%;
 `;
 
 HeaderText.displayName = 'Card.HeaderText';

--- a/components/List/__snapshots__/List.unit.test.jsx.snap
+++ b/components/List/__snapshots__/List.unit.test.jsx.snap
@@ -374,7 +374,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;
@@ -500,7 +502,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;
@@ -881,7 +885,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/components/List/sub-components/__snapshots__/Content.unit.test.jsx.snap
+++ b/components/List/sub-components/__snapshots__/Content.unit.test.jsx.snap
@@ -165,7 +165,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/components/List/sub-components/__snapshots__/Header.unit.test.jsx.snap
+++ b/components/List/sub-components/__snapshots__/Header.unit.test.jsx.snap
@@ -97,6 +97,8 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/components/List/sub-components/__snapshots__/Item.unit.test.jsx.snap
+++ b/components/List/sub-components/__snapshots__/Item.unit.test.jsx.snap
@@ -189,7 +189,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/components/List/sub-components/__snapshots__/SubHeader.unit.test.jsx.snap
+++ b/components/List/sub-components/__snapshots__/SubHeader.unit.test.jsx.snap
@@ -97,6 +97,8 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
+++ b/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
@@ -6,6 +6,9 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  overflow: hidden;
+  max-width: 100%;
+  display: inline-block;
 }
 
 .c7 {
@@ -398,6 +401,9 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  overflow: hidden;
+  max-width: 100%;
+  display: inline-block;
 }
 
 .c7 {
@@ -1408,7 +1414,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                       "isStatic": true,
                       "lastClassName": "c5",
                       "rules": Array [
-                        "flex-grow:1;",
+                        "flex-grow:1;overflow:hidden;max-width:100%;display:inline-block;",
                       ],
                     },
                     "displayName": "Card.HeaderText",
@@ -2310,7 +2316,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                       "isStatic": true,
                                       "lastClassName": "c5",
                                       "rules": Array [
-                                        "flex-grow:1;",
+                                        "flex-grow:1;overflow:hidden;max-width:100%;display:inline-block;",
                                       ],
                                     },
                                     "displayName": "Card.HeaderText",

--- a/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
+++ b/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
@@ -6,9 +6,9 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  overflow: hidden;
   max-width: 100%;
   display: inline-block;
+  word-break: break-all;
 }
 
 .c7 {
@@ -401,9 +401,9 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  overflow: hidden;
   max-width: 100%;
   display: inline-block;
+  word-break: break-all;
 }
 
 .c7 {
@@ -1414,7 +1414,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                       "isStatic": true,
                       "lastClassName": "c5",
                       "rules": Array [
-                        "flex-grow:1;overflow:hidden;max-width:100%;display:inline-block;",
+                        "flex-grow:1;max-width:100%;display:inline-block;word-break:break-all;",
                       ],
                     },
                     "displayName": "Card.HeaderText",
@@ -2316,7 +2316,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                       "isStatic": true,
                                       "lastClassName": "c5",
                                       "rules": Array [
-                                        "flex-grow:1;overflow:hidden;max-width:100%;display:inline-block;",
+                                        "flex-grow:1;max-width:100%;display:inline-block;word-break:break-all;",
                                       ],
                                     },
                                     "displayName": "Card.HeaderText",

--- a/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
+++ b/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
@@ -6,9 +6,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  max-width: 100%;
-  display: inline-block;
-  word-break: break-all;
+  width: 100%;
 }
 
 .c7 {
@@ -401,9 +399,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  max-width: 100%;
-  display: inline-block;
-  word-break: break-all;
+  width: 100%;
 }
 
 .c7 {
@@ -1414,7 +1410,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                       "isStatic": true,
                       "lastClassName": "c5",
                       "rules": Array [
-                        "flex-grow:1;max-width:100%;display:inline-block;word-break:break-all;",
+                        "flex-grow:1;width:100%;",
                       ],
                     },
                     "displayName": "Card.HeaderText",
@@ -2316,7 +2312,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                       "isStatic": true,
                                       "lastClassName": "c5",
                                       "rules": Array [
-                                        "flex-grow:1;max-width:100%;display:inline-block;word-break:break-all;",
+                                        "flex-grow:1;width:100%;",
                                       ],
                                     },
                                     "displayName": "Card.HeaderText",

--- a/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
+++ b/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
@@ -381,7 +381,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;


### PR DESCRIPTION
:+1:  @rapahaeru 

## What this PR does:
Fix card title that breaks when you are in IE browsers and resolution with width less tan 350px.

## How to test:

1. Build the project and get the `dist` folder content.
2. Open a project with `Card` component of Quantum.
3. Open the `@node_modules/@catho/quantum` and overwrite the content with the `dist` folder content.
4. Build the project and serve in a port.
5. Test in IE browser with `xsmall` resolutions.
6. To simulate, try to get cards with titles that have two lines or more.