### PR TITLE
Adding event payload and changed value back onChange event at <Input />

### DIFF
--- a/components/Input/Input.jsx
+++ b/components/Input/Input.jsx
@@ -106,7 +106,7 @@ class Input extends React.Component {
       currentValue: inputValue,
     });
 
-    onChange();
+    onChange(ev, { inputValue });
   };
 
   _changeType = type => {


### PR DESCRIPTION
As pointed in #134, this PR intends to add back the behavior of the onChange event of the <Input /> component to return the event object and new payload to the parent callback.

If this is an intentional behavior, please ignore this PR.