### PR TITLE
fix(input): adds parameter to onchange function on input component

### DIFF
--- a/components/Input/Input.jsx
+++ b/components/Input/Input.jsx
@@ -106,7 +106,7 @@ class Input extends React.Component {
       currentValue: inputValue,
     });
 
-    onChange();
+    onChange(ev);
   };
 
   _changeType = type => {


### PR DESCRIPTION
closes #134 
## What this PR does
Adds a parameter `event` to `onChange` function on `Input` component.
Today we cannot get the event props in `onChange` function prop.