### PR TITLE
Feat/regression tests on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,25 @@ node_js:
 
 # branches:
 #   only:
-#     - feat/regression-tests-on-ci
+#     - master
 
 jobs:
   include:
-    - stage: release
-      if: branch = feat/regression-tests-on-ci
-
+    - stage: unit tests
       node_js: lts/*
-
       skip_cleanup: true
       script:
-        - echo "RODOU SOMENTE SELECIONADA"
+        - yarn test:components
 
-      #   skip_cleanup: true
-      #   script:
-      #     - yarn semantic-release
+    - stage: regression tests
+      node_js: lts/*
+      skip_cleanup: true
+      script:
+        - yarn build:regression
+
+    - stage: release
+      if: branch = master
+      node_js: lts/*
+      skip_cleanup: true
+      script:
+        - yarn semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,21 @@ language: node_js
 node_js:
   - 8
 
-branches:
-  only:
-    - master
+# branches:
+#   only:
+#     - feat/regression-tests-on-ci
 
 jobs:
   include:
     - stage: release
+      if: branch = feat/regression-tests-on-ci
+
       node_js: lts/*
 
-      script: yarn build
+      skip_cleanup: true
+      script:
+        - echo "RODOU SOMENTE SELECIONADA"
 
-      deploy:
-        provider: script
-        skip_cleanup: true
-        script:
-          - yarn semantic-release
+      #   skip_cleanup: true
+      #   script:
+      #     - yarn semantic-release

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:js": "yarn lint ./*.js",
     "lint:all": "yarn lint:components && yarn lint:stories && yarn lint:js",
     "lint": "eslint --ext js,jsx --quiet",
-    "prepush": "yarn lint:all && yarn test:components && yarn build:regression",
+    "prepush": "yarn lint:all && yarn test:components",
     "storybook": "start-storybook -s static",
     "format": "prettier --write ./**/*.{js,jsx,json}",
     "deploy-storybook": "storybook-to-ghpages",


### PR DESCRIPTION
## Description
This PR:
- adds unit and regression tests to every branch that is pushed to quantum.
- removes regression tests from prepush

## Setup
On Travis website, quantum project, right part of the screen, `more options > trigger build` and select `feat/regression-tests-on-ci` branch.

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests: ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
