### PR TITLE
test(Hamburger): removes console on component

### DIFF
--- a/components/Hamburger/Hamburger.jsx
+++ b/components/Hamburger/Hamburger.jsx
@@ -10,8 +10,6 @@ const HAMBURGER_SIZE = 24;
 const NOTIFICATION_SIZE = 7;
 
 const getColors = ({ inverted }) => {
-  console.log('inverted', inverted);
-
   const weight = !inverted ? 0 : 900;
 
   return colors.neutral[weight];


### PR DESCRIPTION
## Description
In hamburger component was left a console log behind. This console is showing in unit tests loads.

## Review guide
- [ ] Unit tests (yarn test:components)