### PR TITLE
Fix/circular loader

### DIFF
--- a/components/CircularLoader/CircularLoader.jsx
+++ b/components/CircularLoader/CircularLoader.jsx
@@ -101,13 +101,7 @@ const CircularLoader = props => {
   return (
     <Wrapper size={size} gutter={gutter} role="progressbar">
       <Content color={color} viewBox="22 22 44 44">
-        <Circle
-          STROKE-WIDTH={strokeWidth}
-          cx={cx}
-          cy={cy}
-          r={r}
-          color={color}
-        />
+        <Circle strokeWidth={strokeWidth} cx={cx} cy={cy} r={r} color={color} />
       </Content>
     </Wrapper>
   );

--- a/components/CircularLoader/CircularLoader.jsx
+++ b/components/CircularLoader/CircularLoader.jsx
@@ -50,16 +50,23 @@ const circularDash = keyframes`
   }
 `;
 
+const circleProps = {
+  cx: 44,
+  cy: 44,
+  r: 20.2,
+  strokeWidth: 3.6,
+};
+
 const Circle = styled.circle`
   animation: ${circularDash} 1.4s ease-in-out infinite;
-  cx: 44px;
-  cy: 44px;
+  cx: ${circleProps.cx}px;
+  cy: ${circleProps.cy}px;
   fill: none;
   line-height: 1;
-  r: 20.2px;
+  r: ${circleProps.r}px;
   stroke-dasharray: 80px, 200px;
   stroke-dashoffset: 0px;
-  stroke-width: 3.6;
+  stroke-width: ${circleProps.strokeWidth}px;
   stroke: currentColor;
 
   ${({ color }) => `
@@ -89,10 +96,18 @@ const CircularLoader = props => {
     },
   } = props;
 
+  const { cx, cy, r, strokeWidth } = circleProps;
+
   return (
     <Wrapper size={size} gutter={gutter} role="progressbar">
       <Content color={color} viewBox="22 22 44 44">
-        <Circle color={color} />
+        <Circle
+          STROKE-WIDTH={strokeWidth}
+          cx={cx}
+          cy={cy}
+          r={r}
+          color={color}
+        />
       </Content>
     </Wrapper>
   );

--- a/components/CircularLoader/CircularLoader.jsx
+++ b/components/CircularLoader/CircularLoader.jsx
@@ -21,6 +21,8 @@ const Content = styled.svg`
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
 
   ${({ color }) => `
     color: ${color};
@@ -50,11 +52,11 @@ const circularDash = keyframes`
 
 const Circle = styled.circle`
   animation: ${circularDash} 1.4s ease-in-out infinite;
-  cx: 44;
-  cy: 44;
+  cx: 44px;
+  cy: 44px;
   fill: none;
   line-height: 1;
-  r: 20.2;
+  r: 20.2px;
   stroke-dasharray: 80px, 200px;
   stroke-dashoffset: 0px;
   stroke-width: 3.6;

--- a/components/CircularLoader/__snapshots__/CircularLoader.unit.test.jsx.snap
+++ b/components/CircularLoader/__snapshots__/CircularLoader.unit.test.jsx.snap
@@ -53,6 +53,7 @@ exports[`CircularLoader component Should match the snapshot of a simple circular
       cx={44}
       cy={44}
       r={20.2}
+      strokeWidth={3.6}
     />
   </svg>
 </div>

--- a/components/CircularLoader/__snapshots__/CircularLoader.unit.test.jsx.snap
+++ b/components/CircularLoader/__snapshots__/CircularLoader.unit.test.jsx.snap
@@ -9,17 +9,19 @@ exports[`CircularLoader component Should match the snapshot of a simple circular
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  width: 100%;
+  height: 100%;
   color: #1250C4;
 }
 
 .c2 {
   -webkit-animation: dPEoa 1.4s ease-in-out infinite;
   animation: dPEoa 1.4s ease-in-out infinite;
-  cx: 44;
-  cy: 44;
+  cx: 44px;
+  cy: 44px;
   fill: none;
   line-height: 1;
-  r: 20.2;
+  r: 20.2px;
   stroke-dasharray: 80px,200px;
   stroke-dashoffset: 0px;
   stroke-width: 3.6;

--- a/components/CircularLoader/__snapshots__/CircularLoader.unit.test.jsx.snap
+++ b/components/CircularLoader/__snapshots__/CircularLoader.unit.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`CircularLoader component Should match the snapshot of a simple circular
   r: 20.2px;
   stroke-dasharray: 80px,200px;
   stroke-dashoffset: 0px;
-  stroke-width: 3.6;
+  stroke-width: 3.6px;
   stroke: currentColor;
   color: #1250C4;
 }
@@ -50,6 +50,9 @@ exports[`CircularLoader component Should match the snapshot of a simple circular
     <circle
       className="c2"
       color="#1250C4"
+      cx={44}
+      cy={44}
+      r={20.2}
     />
   </svg>
 </div>


### PR DESCRIPTION
## Description
Fix `CircularLoader` on IE and Firefox.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation