### PR TITLE
fix(QTM-150): fixes the display grid fallback in Edge 15

### DIFF
--- a/components/Grid/sub-components/Col.jsx
+++ b/components/Grid/sub-components/Col.jsx
@@ -10,9 +10,9 @@ const columnGrid = ({ size, offset }) => {
   return `grid-column: ${offsetStyle} span ${size || 12};`;
 };
 
-const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter }) => {
-  const calculedWidth = size ? (100 / 12) * size : 100;
-  const calculedOffset = offset ? (100 / 12) * offset : 100;
+const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter, maxColumns }) => {
+  const calculedWidth = size ? (100 / maxColumns) * size : 100;
+  const calculedOffset = offset ? (100 / maxColumns) * offset : 100;
   const calculedGutter = calcGutter(
     CSSVariables({
       theme: {
@@ -26,13 +26,12 @@ const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter }) => {
   const offsetStyle = offset
     ? `
     margin-left: calc(${calculedOffset.toFixed(3)}% + ${
-        calculedGutter > 0 ? `(${calculedGutter}px / (12 / ${offset})` : `0px`
-      } ) );
+    calculedGutter > 0 ? `(${calculedGutter}px / (${maxColumns} / ${offset})` : `0px`
+    } ) );
 
     &:first-child {
-      margin-left: calc(${calculedOffset.toFixed(3)}% + ${
-        calculedGutter > 0 ? `(${calculedGutter}px / (12 / ${offset})` : `0px`
-      } ) );
+      margin-left: 0px;
+    } ) );
     }
     &:last-child {
       margin-right: 0;
@@ -40,11 +39,8 @@ const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter }) => {
   
   `
     : `
-    margin-left: ${
-      calculedGutter > 0 ? `calc(${calculedGutter}px / 2)` : '0px'
-    };
     margin-right: ${
-      calculedGutter > 0 ? `calc(${calculedGutter}px / 2)` : '0px'
+    calculedGutter > 0 ? `calc(${calculedGutter}px / 2)` : '0px'
     };
     
     &:first-child {
@@ -58,9 +54,9 @@ const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter }) => {
   const colWidth =
     calculedGutter > 0
       ? `calc(${calculedWidth.toFixed(
-          3,
-        )}% - ${calculedGutter}px + (${calculedGutter}px / (12 / ${size ||
-          12}) ) )`
+        3,
+      )}% - ${calculedGutter}px + (${calculedGutter}px / (${maxColumns} / ${size ||
+      maxColumns}) ) )`
       : `${calculedWidth.toFixed(3)}%`;
 
   return `
@@ -114,24 +110,25 @@ const columnPosition = (
   };
 
   const { size, offset } = screenDefinitions[breakpoint];
-
+  const maxColumns = breakpoints[breakpoint].columns;
   return q`
     @supports ( display: grid ) {
       ${columnGrid({
-        size,
-        offset,
-        breakpoint,
-      })}
+    size,
+    offset,
+    breakpoint,
+  })}
     }
 
     @supports not ( display: grid ) {
       ${columnGridLess({
-        size,
-        offset,
-        breakpoint,
-        noGutters,
-        gutter,
-      })}
+    size,
+    offset,
+    breakpoint,
+    noGutters,
+    gutter,
+    maxColumns,
+  })}
     }
   `;
 };

--- a/components/Grid/sub-components/Col.jsx
+++ b/components/Grid/sub-components/Col.jsx
@@ -10,7 +10,14 @@ const columnGrid = ({ size, offset }) => {
   return `grid-column: ${offsetStyle} span ${size || 12};`;
 };
 
-const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter, maxColumns }) => {
+const columnGridLess = ({
+  size,
+  offset,
+  breakpoint,
+  noGutters,
+  gutter,
+  maxColumns,
+}) => {
   const calculedWidth = size ? (100 / maxColumns) * size : 100;
   const calculedOffset = offset ? (100 / maxColumns) * offset : 100;
   const calculedGutter = calcGutter(
@@ -26,13 +33,15 @@ const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter, maxColumn
   const offsetStyle = offset
     ? `
     margin-left: calc(${calculedOffset.toFixed(3)}% + ${
-    calculedGutter > 0 ? `(${calculedGutter}px / (${maxColumns} / ${offset})` : `0px`
-    } ) );
+        calculedGutter > 0
+          ? `(${calculedGutter}px / (${maxColumns} / ${offset})`
+          : `0px`
+      } ) );
 
     &:first-child {
       margin-left: 0px;
-    } ) );
     }
+
     &:last-child {
       margin-right: 0;
     }
@@ -40,7 +49,7 @@ const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter, maxColumn
   `
     : `
     margin-right: ${
-    calculedGutter > 0 ? `calc(${calculedGutter}px / 2)` : '0px'
+      calculedGutter > 0 ? `calc(${calculedGutter}px / 2)` : '0px'
     };
     
     &:first-child {
@@ -54,9 +63,9 @@ const columnGridLess = ({ size, offset, breakpoint, noGutters, gutter, maxColumn
   const colWidth =
     calculedGutter > 0
       ? `calc(${calculedWidth.toFixed(
-        3,
-      )}% - ${calculedGutter}px + (${calculedGutter}px / (${maxColumns} / ${size ||
-      maxColumns}) ) )`
+          3,
+        )}% - ${calculedGutter}px + (${calculedGutter}px / (${maxColumns} / ${size ||
+          maxColumns}) ) )`
       : `${calculedWidth.toFixed(3)}%`;
 
   return `
@@ -114,21 +123,21 @@ const columnPosition = (
   return q`
     @supports ( display: grid ) {
       ${columnGrid({
-    size,
-    offset,
-    breakpoint,
-  })}
+        size,
+        offset,
+        breakpoint,
+      })}
     }
 
     @supports not ( display: grid ) {
       ${columnGridLess({
-    size,
-    offset,
-    breakpoint,
-    noGutters,
-    gutter,
-    maxColumns,
-  })}
+        size,
+        offset,
+        breakpoint,
+        noGutters,
+        gutter,
+        maxColumns,
+      })}
     }
   `;
 };


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-150
⚠️  resolves issue https://github.com/catho/quantum/issues/179

## Setup
to view the components behavior, run `yarn storybook`

## How to test
- compare the alignments of the Grid in this branch with the production : https://catho.github.io/quantum/?path=/story/foundation--grid-system
- Simulate a new aplication it implements the Quantum Grid and test in Edge 15

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation