### PR TITLE
feat(Dropdown): Add property to ignore special chars

### DIFF
--- a/components/Dropdown/Dropdown.jsx
+++ b/components/Dropdown/Dropdown.jsx
@@ -302,6 +302,7 @@ const Dropdown = ({
   autocomplete,
   theme,
   id,
+  ignoreSpecialChars,
   ...rest
 }) => {
   const _buttonLabel = selectedItem ? _getLabel(selectedItem) : placeholder;
@@ -325,13 +326,30 @@ const Dropdown = ({
 
   const [_id] = useState(id || ID_GENERATOR.next().value);
 
-  const inputFilter = value =>
-    items.filter(
-      item =>
-        _getValue(item)
-          .toLowerCase()
-          .indexOf(value.toLowerCase()) > -1,
+  const normalizeChars = value =>
+    value.replace(
+      /([àáâãäå])|([çčć])|([èéêë])|([ìíîï])|([òóôõöø])|([ùúûü])|([-_])/g,
+      (str, a, c, e, i, o, u, hifen) => {
+        if (a) return 'a';
+        if (c) return 'c';
+        if (e) return 'e';
+        if (i) return 'i';
+        if (o) return 'o';
+        if (u) return 'u';
+        if (hifen) return ' ';
+        return '';
+      },
     );
+
+  const inputFilter = value =>
+    items.filter(item => {
+      let itemValue = _getValue(item).toLowerCase();
+      if (ignoreSpecialChars) {
+        itemValue = normalizeChars(itemValue);
+        return itemValue.indexOf(normalizeChars(value.toLowerCase())) > -1;
+      }
+      return itemValue.indexOf(value.toLowerCase()) > -1;
+    });
 
   return (
     <FieldGroup>
@@ -458,6 +476,7 @@ Dropdown.defaultProps = {
   items: [],
   onChange: () => {},
   theme: { colors, spacing, baseFontSize },
+  ignoreSpecialChars: false,
 };
 
 Dropdown.propTypes = {
@@ -485,6 +504,7 @@ Dropdown.propTypes = {
     spacing: PropTypes.object,
     baseFontSize: PropTypes.number,
   }),
+  ignoreSpecialChars: PropTypes.bool,
 };
 
 export default Dropdown;

--- a/components/Dropdown/Dropdown.jsx
+++ b/components/Dropdown/Dropdown.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Downshift from 'downshift';
 import Icon from '../Icon/Icon';
-import { FieldGroup, shadow, uniqId } from '../shared';
+import { FieldGroup, shadow, uniqId, normalizeChars } from '../shared';
 import { colors, spacing, baseFontSize } from '../shared/theme';
 
 import {
@@ -325,21 +325,6 @@ const Dropdown = ({
   const hasLabel = !!label;
 
   const [_id] = useState(id || ID_GENERATOR.next().value);
-
-  const normalizeChars = value =>
-    value.replace(
-      /([àáâãäå])|([çčć])|([èéêë])|([ìíîï])|([òóôõöø])|([ùúûü])|([-_])/g,
-      (str, a, c, e, i, o, u, hifen) => {
-        if (a) return 'a';
-        if (c) return 'c';
-        if (e) return 'e';
-        if (i) return 'i';
-        if (o) return 'o';
-        if (u) return 'u';
-        if (hifen) return ' ';
-        return '';
-      },
-    );
 
   const inputFilter = value =>
     items.filter(item => {

--- a/components/Dropdown/Dropdown.unit.test.jsx
+++ b/components/Dropdown/Dropdown.unit.test.jsx
@@ -163,6 +163,7 @@ describe('with autocomplete property', () => {
       label: 'Belém - PA',
     },
   ];
+
   it('should display items ignoring special chars', () => {
     const component = mount(
       <Dropdown
@@ -177,7 +178,50 @@ describe('with autocomplete property', () => {
       .find('DropInput')
       .find('input')
       .simulate('change', { target: { value: 'sao' } });
-    // console.log('=====!!!', component.find('DropItem').find('span').text());
-    // console.log('=====', component.find('DropItem').find('span').debug());
+    expect(
+      component
+        .find('DropItem')
+        .find('span')
+        .text(),
+    ).toEqual(items[0].label);
+
+    component
+      .find('DropInput')
+      .find('input')
+      .simulate('change', { target: { value: 'rio-de-' } });
+    expect(
+      component
+        .find('DropItem')
+        .find('span')
+        .text(),
+    ).toEqual(items[1].label);
+  });
+
+  it('should not display items with special chars', () => {
+    const component = mount(
+      <Dropdown autocomplete onChange={mockFn} items={items} />,
+    );
+
+    component
+      .find('DropInput')
+      .find('input')
+      .simulate('change', { target: { value: 'sao' } });
+    expect(
+      component
+        .find('DropItem')
+        .find('span')
+        .exists(),
+    ).toEqual(false);
+
+    component
+      .find('DropInput')
+      .find('input')
+      .simulate('change', { target: { value: 'São' } });
+    expect(
+      component
+        .find('DropItem')
+        .find('span')
+        .text(),
+    ).toEqual(items[0].label);
   });
 });

--- a/components/Dropdown/Dropdown.unit.test.jsx
+++ b/components/Dropdown/Dropdown.unit.test.jsx
@@ -146,3 +146,38 @@ describe('with an "onChange" callback set', () => {
     expect(mockFn).toBeCalledWith(selectedItem);
   });
 });
+
+describe('with autocomplete property', () => {
+  const mockFn = jest.fn();
+  const items = [
+    {
+      value: 'São Paulo',
+      label: 'São Paulo - SP',
+    },
+    {
+      value: 'Rio de Janeiro',
+      label: 'Rio de Janeiro - RJ',
+    },
+    {
+      value: 'Belém',
+      label: 'Belém - PA',
+    },
+  ];
+  it('should display items ignoring special chars', () => {
+    const component = mount(
+      <Dropdown
+        autocomplete
+        ignoreSpecialChars
+        onChange={mockFn}
+        items={items}
+      />,
+    );
+
+    component
+      .find('DropInput')
+      .find('input')
+      .simulate('change', { target: { value: 'sao' } });
+    // console.log('=====!!!', component.find('DropItem').find('span').text());
+    // console.log('=====', component.find('DropItem').find('span').debug());
+  });
+});

--- a/components/shared/index.js
+++ b/components/shared/index.js
@@ -10,6 +10,7 @@ import * as INPUT_STYLE from './inputStyle';
 import hexToRgba from './hexToRgba';
 import shadow from './shadow';
 import HiddenInput from './HiddenInput';
+import normalizeChars from './normalizeChars';
 
 export {
   ErrorMessage,
@@ -24,4 +25,5 @@ export {
   hexToRgba,
   shadow,
   HiddenInput,
+  normalizeChars,
 };

--- a/components/shared/normalizeChars.js
+++ b/components/shared/normalizeChars.js
@@ -1,0 +1,16 @@
+const normalizeChars = value =>
+  value.replace(
+    /([àáâãäå])|([çčć])|([èéêë])|([ìíîï])|([òóôõöø])|([ùúûü])|([-_])/g,
+    (str, a, c, e, i, o, u, hifen) => {
+      if (a) return 'a';
+      if (c) return 'c';
+      if (e) return 'e';
+      if (i) return 'i';
+      if (o) return 'o';
+      if (u) return 'u';
+      if (hifen) return ' ';
+      return '';
+    },
+  );
+
+export default normalizeChars;

--- a/components/shared/normalizeChars.unit.test.js
+++ b/components/shared/normalizeChars.unit.test.js
@@ -1,0 +1,9 @@
+import normalizeChars from './normalizeChars';
+
+describe('normalizeChars function', () => {
+  it('remove special chars in string correctly', () => {
+    expect(normalizeChars('São Paulo')).toBe('Sao Paulo');
+    expect(normalizeChars('río-de-Jâneiro')).toBe('rio de Janeiro');
+    expect(normalizeChars('ãçí_-aâsd')).toBe('aci  aasd');
+  });
+});

--- a/stories/Dropdown/Dropdown.story.jsx
+++ b/stories/Dropdown/Dropdown.story.jsx
@@ -22,6 +22,7 @@ import {
   Disabled,
   Controlled,
   AutoComplete,
+  AutoCompleteWithSpecialChars,
   WithImages,
 } from './examples';
 
@@ -78,11 +79,15 @@ storiesOf('Forms', module).add('Dropdown', () => (
           <DropdownExample component={Simple} position="1" />
           <DropdownExample component={CustomLabel} position="2" />
           <DropdownExample component={AutoComplete} position="3" />
-          <DropdownExample component={RequiredMark} position="4" />
-          <DropdownExample component={WithError} position="5" />
-          <DropdownExample component={Disabled} position="6" />
-          <DropdownExample component={WithImages} position="7" />
-          <DropdownExample component={Controlled} position="8" />
+          <DropdownExample
+            component={AutoCompleteWithSpecialChars}
+            position="4"
+          />
+          <DropdownExample component={RequiredMark} position="5" />
+          <DropdownExample component={WithError} position="6" />
+          <DropdownExample component={Disabled} position="7" />
+          <DropdownExample component={WithImages} position="8" />
+          <DropdownExample component={Controlled} position="9" />
         </StoryContainer>
       </Tab>
       <Tab title="API">

--- a/stories/Dropdown/examples.jsx
+++ b/stories/Dropdown/examples.jsx
@@ -157,6 +157,29 @@ AutoComplete.CODE = `<Dropdown
   items={['Lemon', 'Banana', 'Strawberry', 'Orange', 'Avocado']}
 />`;
 
+const AutoCompleteWithSpecialChars = () => (
+  <Dropdown
+    autocomplete
+    ignoreSpecialChars
+    helperText="Try to type: sao-paulo"
+    label="Autocomplete ignoring special characters"
+    placeholder="Start typing..."
+    items={[
+      'São Paulo - SP',
+      'Rio de Janeiro - RJ',
+      'Florianópolis - SC',
+      'Salvador - BA',
+    ]}
+  />
+);
+AutoCompleteWithSpecialChars.CODE = `<Dropdown
+  autocomplete
+  ignoreSpecialChars
+  label="Autocomplete ignoring special characters"
+  placeholder="Start typing..."
+  items={['São Paulo - SP', 'Rio de Janeiro - RJ', 'Florianópolis - SC', 'Salvador - BA']}
+/>`;
+
 const WithImages = () => (
   <Dropdown
     helperText="this dropdown has images in the list"
@@ -219,5 +242,6 @@ export {
   Disabled,
   Controlled,
   AutoComplete,
+  AutoCompleteWithSpecialChars,
   WithImages,
 };


### PR DESCRIPTION
## Description
The current version of the component Dropdown when used how autocomplete don't return list if input is not identical, exemple with a itens list how [ 'são paulo',  'belém'] just return if input is 'são paulo' or 'belém'.
With this parameter "ignoreSpecialChars" we can input 'sao paulo' and return list the suggest corrctly.

Changes list:
* Add new parameter in Dropdown component
* Create a function to remove special chars inside the Dropdown component
* Add unit test for Dropdown autocomplete with and without new prop
* Add new parameter in doc storybook 

## Setup

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [x] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [x] Edge
  - [x] IE 11
  - [ ] Firefox
  - [x] Chrome
  - [ ] Safari
  - [x] Mobile
- [ ] Ux review validation