### PR TITLE
fix(Modal): locks scroll when modal is open

### DIFF
--- a/components/GlobalStyle/sub-components/Typography.jsx
+++ b/components/GlobalStyle/sub-components/Typography.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 import { colors } from '../../shared/theme';
+import isSSRRender from '../../shared/isSSRRender';
 
 const Style = createGlobalStyle`
 * {
@@ -61,7 +62,7 @@ const NunitoFontFamily = createGlobalStyle`
 const Typography = () => (
   <>
     <Style />
-    {typeof window === 'undefined' ? (
+    {isSSRRender() ? (
       <link
         href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,600,700,400i,600i,700i&display=swap"
         rel="stylesheet"

--- a/components/GlobalStyle/sub-components/Typography.jsx
+++ b/components/GlobalStyle/sub-components/Typography.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 import { colors } from '../../shared/theme';
-import isSSRRender from '../../shared/isSSRRender';
+import isSSR from '../../shared/isSSR';
 
 const Style = createGlobalStyle`
 * {
@@ -62,7 +62,7 @@ const NunitoFontFamily = createGlobalStyle`
 const Typography = () => (
   <>
     <Style />
-    {isSSRRender() ? (
+    {isSSR() ? (
       <link
         href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,600,700,400i,600i,700i&display=swap"
         rel="stylesheet"

--- a/components/Modal/Modal.jsx
+++ b/components/Modal/Modal.jsx
@@ -9,7 +9,7 @@ import { query } from '../Grid/sub-components/shared';
 import { Content, Header, HeaderText, Title, Footer } from './sub-components';
 import { hexToRgba } from '../shared';
 import { breakpoints, colors, spacing, components } from '../shared/theme';
-import isSSRRender from '../shared/isSSRRender';
+import isSSR from '../shared/isSSR';
 
 const closeButtonPadding = spacing.medium;
 
@@ -129,7 +129,7 @@ class Modal extends React.Component {
   }
 
   setBodyOverflow = value => {
-    if (isSSRRender()) return;
+    if (isSSR()) return;
 
     const { body } = document;
     body.style.overflow = value;

--- a/components/Modal/Modal.jsx
+++ b/components/Modal/Modal.jsx
@@ -95,8 +95,8 @@ class Modal extends React.Component {
 
   componentDidMount() {
     const { body } = document;
-
     body.appendChild(this.modalOverlay);
+    this.setBodyOverflow('hidden');
 
     this.focusableElements = this.modalOverlay.querySelectorAll(
       `a[href],
@@ -120,11 +120,17 @@ class Modal extends React.Component {
   componentWillUnmount() {
     const { body } = document;
     this.focusedElementBeforeOpen.focus();
+    this.setBodyOverflow('auto');
 
     body.removeChild(this.modalOverlay);
     window.removeEventListener('keydown', this.handleKeyDown);
     window.removeEventListener('keydown', this.handleEscKey);
   }
+
+  setBodyOverflow = value => {
+    const { body } = document;
+    body.style.overflow = value;
+  };
 
   handleClickOutside = ({ target }) => {
     const { onClose } = this.props;

--- a/components/Modal/Modal.jsx
+++ b/components/Modal/Modal.jsx
@@ -9,6 +9,7 @@ import { query } from '../Grid/sub-components/shared';
 import { Content, Header, HeaderText, Title, Footer } from './sub-components';
 import { hexToRgba } from '../shared';
 import { breakpoints, colors, spacing, components } from '../shared/theme';
+import isSSRRender from '../shared/isSSRRender';
 
 const closeButtonPadding = spacing.medium;
 
@@ -128,6 +129,8 @@ class Modal extends React.Component {
   }
 
   setBodyOverflow = value => {
+    if (isSSRRender()) return;
+
     const { body } = document;
     body.style.overflow = value;
   };

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { BREAKPOINTS } from '../shared';
 import Desktop from './sub-components/Desktop';
 import Mobile from './sub-components/Mobile';
+import isSSRRender from '../shared/isSSRRender';
 
 const Wrapper = styled.nav`
   align-items: center;
@@ -59,8 +60,7 @@ class Pagination extends React.Component {
     };
 
     const width =
-      (typeof window !== 'undefined' && window.innerWidth) ||
-      BREAKPOINTS.small.width;
+      (!isSSRRender() && window.innerWidth) || BREAKPOINTS.small.width;
 
     const Component = width > BREAKPOINTS.small.width ? Desktop : Mobile;
 

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { BREAKPOINTS } from '../shared';
 import Desktop from './sub-components/Desktop';
 import Mobile from './sub-components/Mobile';
-import isSSRRender from '../shared/isSSRRender';
+import isSSR from '../shared/isSSR';
 
 const Wrapper = styled.nav`
   align-items: center;
@@ -59,8 +59,7 @@ class Pagination extends React.Component {
       return pageHref(page);
     };
 
-    const width =
-      (!isSSRRender() && window.innerWidth) || BREAKPOINTS.small.width;
+    const width = (!isSSR() && window.innerWidth) || BREAKPOINTS.small.width;
 
     const Component = width > BREAKPOINTS.small.width ? Desktop : Mobile;
 

--- a/components/shared/isSSR.js
+++ b/components/shared/isSSR.js
@@ -1,3 +1,3 @@
 const isSSR = () => typeof window === 'undefined';
 
-export default isSSRRender;
+export default isSSR;

--- a/components/shared/isSSRRender.js
+++ b/components/shared/isSSRRender.js
@@ -1,0 +1,3 @@
+const isSSRRender = () => typeof window === 'undefined';
+
+export default isSSRRender;

--- a/components/shared/isSSRRender.js
+++ b/components/shared/isSSRRender.js
@@ -1,3 +1,3 @@
-const isSSRRender = () => typeof window === 'undefined';
+const isSSR = () => typeof window === 'undefined';
 
 export default isSSRRender;


### PR DESCRIPTION
## Description
When the Modal is open, the background must be blocked in scroll or tap events.
https://jirasoftware.catho.com.br/browse/QTM-164

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [x] Unit tests (yarn test:components)
- [x] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation