### PR TITLE
[Refactor] Adding children as string or elements in the <RadioGroup.Radio />

### DIFF
--- a/components/RadioGroup/Radio.jsx
+++ b/components/RadioGroup/Radio.jsx
@@ -251,7 +251,7 @@ Radio.displayName = 'RadioGroup.Radio';
 Radio.propTypes = {
   disabled: PropTypes.bool,
   error: PropTypes.bool,
-  children: PropTypes.string,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   label: PropTypes.string,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func,

--- a/components/RadioGroup/Radio.unit.test.jsx
+++ b/components/RadioGroup/Radio.unit.test.jsx
@@ -23,5 +23,14 @@ describe('<RadioGroup.Radio />', () => {
       const component = <Radio value="Foo">Foo</Radio>;
       expect(renderer.create(component).toJSON()).toMatchSnapshot();
     });
+
+    it('children with element', () => {
+      const component = (
+        <Radio value="Foo">
+          <span>Foo</span>
+        </Radio>
+      );
+      expect(renderer.create(component).toJSON()).toMatchSnapshot();
+    });
   });
 });

--- a/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
@@ -200,6 +200,208 @@ exports[`<RadioGroup.Radio /> snapshot children 1`] = `
 </label>
 `;
 
+exports[`<RadioGroup.Radio /> snapshot children with element 1`] = `
+.c2 {
+  border: 0;
+  height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 0;
+}
+
+.c4 {
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+  height: 24px;
+  position: relative;
+  top: 6px;
+  width: 24px;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  margin-right: 8px;
+}
+
+.c4:after {
+  border-radius: 50%;
+  content: '';
+  display: none;
+  height: 60%;
+  left: 20%;
+  position: absolute;
+  top: 20%;
+  width: 60%;
+  background-color: #1250C4;
+}
+
+.c0 {
+  display: block;
+  margin-bottom: 5px;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c0 .c1:checked ~ .c3 {
+  border-color: #1250C4;
+}
+
+.c0 .c1:checked ~ .c3:after {
+  background-color: #1250C4;
+  display: block;
+}
+
+.c0 .c1:focus ~ .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c0:hover .c3,
+.c0:focus .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c0 .c1:checked:disabled ~ .c3 {
+  background-color: #999999;
+  border-color: #999999;
+  box-shadow: inset 0 0 0 3.5px #ffffff;
+}
+
+.c5 .c1:checked ~ .c3 {
+  border-color: #1250C4;
+}
+
+.c5 .c1:checked ~ .c3:after {
+  background-color: #1250C4;
+  display: block;
+}
+
+.c5 .c1:focus ~ .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c5:hover .c3,
+.c5:focus .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c5 .c1:disabled ~ .c3 {
+  background-color: #e0e0e0;
+}
+
+.c5 .c1:checked ~ .c3 {
+  border-color: #ec584e;
+}
+
+.c5 .c1:checked ~ .c3:after {
+  background-color: #ec584e;
+  display: block;
+}
+
+.c5 .c1:checked:disabled {
+  background-color: #999999;
+  border-color: #999999;
+}
+
+.c5 .c1:checked:disabled ~ .c3:after {
+  background-color: #999999;
+}
+
+.c5 .c1:focus ~ .c3 {
+  border-color: #999999;
+  box-shadow: none;
+}
+
+.c5:hover .c3,
+.c5:focus .c3 {
+  border-color: #999999;
+  box-shadow: none;
+}
+
+.c5 .c1:checked:disabled ~ .c3 {
+  background-color: #999999;
+  border-color: #999999;
+  box-shadow: inset 0 0 0 3.5px #ffffff;
+}
+
+.c6 .c1:checked ~ .c3 {
+  border-color: #1250C4;
+}
+
+.c6 .c1:checked ~ .c3:after {
+  background-color: #1250C4;
+  display: block;
+}
+
+.c6 .c1:focus ~ .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c6:hover .c3,
+.c6:focus .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c6 .c1:checked ~ .c3 {
+  border-color: #e91b0c;
+}
+
+.c6 .c1:checked ~ .c3:after {
+  background-color: #e91b0c;
+  display: block;
+}
+
+.c6 .c1:focus ~ .c3 {
+  border-color: #e91b0c;
+  box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
+}
+
+.c6 .c3 {
+  border-color: #e91b0c;
+}
+
+.c6:hover .c3,
+.c6:focus .c3 {
+  border-color: #e91b0c;
+  box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
+}
+
+.c6 .c1:checked:disabled ~ .c3 {
+  background-color: #999999;
+  border-color: #999999;
+  box-shadow: inset 0 0 0 3.5px #ffffff;
+}
+
+<label
+  className="c0"
+  disabled={false}
+>
+  <input
+    className="c1 c2"
+    disabled={false}
+    onChange={[Function]}
+    type="radio"
+    value="Foo"
+  />
+  <span
+    className="c3 c4"
+  />
+  <span>
+    Foo
+  </span>
+</label>
+`;
+
 exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
 .c2 {
   border: 0;

--- a/components/RadioGroup/index.d.ts
+++ b/components/RadioGroup/index.d.ts
@@ -1,66 +1,66 @@
 import React from 'react';
 
 export interface RadioProps {
-    disabled?: boolean;
-    error?: boolean;
-    children?: string;
-    label?: string;
-    onChange?: React.ChangeEventHandler<HTMLInputElement>;
-    theme?: {
-        colors?: object;
-        spacing?: object;
-    };
-    value: string;
+  disabled?: boolean;
+  error?: boolean;
+  children?: string | React.ReactNode[] | React.ReactNode;
+  label?: string;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  theme?: {
+    colors?: object;
+    spacing?: object;
+  };
+  value: string;
 }
 
 export type Radio = React.ComponentType<RadioProps>;
 
 export interface RadioButtonProps {
-    checked?: boolean;
-    children?: string;
-    skin?: 'neutral' | 'primary' | 'success' | 'warning' | 'error';
-    disabled?: boolean;
-    error?: boolean;
-    icon?: string;
-    id?: string;
-    inline?: boolean;
-    label?: string;
-    onChange?: React.ChangeEventHandler<HTMLInputElement>;
-    theme?: {
-        baseFontSize?: number;
-        spacing?: object;
-        colors?: object;
-        components?: {
-            button?: object;
-        };
+  checked?: boolean;
+  children?: string;
+  skin?: 'neutral' | 'primary' | 'success' | 'warning' | 'error';
+  disabled?: boolean;
+  error?: boolean;
+  icon?: string;
+  id?: string;
+  inline?: boolean;
+  label?: string;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  theme?: {
+    baseFontSize?: number;
+    spacing?: object;
+    colors?: object;
+    components?: {
+      button?: object;
     };
-    value: string;
+  };
+  value: string;
 }
 
 export type RadioButton = React.ComponentType<RadioButtonProps>;
 
 export interface RadioGroupProps {
-    type?: 'radio' | 'button';
-    options?: Array<{
-        label?: React.ReactNode;
-        value: string;
-        disabled?: boolean;
-    }>;
+  type?: 'radio' | 'button';
+  options?: Array<{
+    label?: React.ReactNode;
+    value: string;
+    disabled?: boolean;
+  }>;
 
-    children?: React.ReactNode[] | React.ReactNode;
-    inline?: boolean;
-    onChange?: React.ChangeEventHandler<HTMLInputElement>;
-    value?: string;
-    error?: string;
-    theme?: {
-        colors?: object;
-        spacing?: object;
-    };
-    name: string;
+  children?: React.ReactNode[] | React.ReactNode;
+  inline?: boolean;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  value?: string;
+  error?: string;
+  theme?: {
+    colors?: object;
+    spacing?: object;
+  };
+  name: string;
 }
 
 export default class RadioGroup extends React.Component<RadioGroupProps> {
-    static Radio: Radio;
+  static Radio: Radio;
 
-    static Button: RadioButton;
+  static Button: RadioButton;
 }

--- a/stories/RadioGroup/RadioGroup.story.jsx
+++ b/stories/RadioGroup/RadioGroup.story.jsx
@@ -66,6 +66,13 @@ stories.add('Radio group', () => (
             <RadioGroupExample {...samples.simpleRadioGroup} />
           </Row>
           <br />
+          <p>... and can use with children </p>
+          <br />
+
+          <Row>
+            <RadioGroupExample {...samples.childrenRadio} />
+          </Row>
+          <br />
 
           <p>
             Also, you can set some properties to <code>RadioGroup</code>, such

--- a/stories/RadioGroup/sub-components/childrenRadio.jsx
+++ b/stories/RadioGroup/sub-components/childrenRadio.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import RadioGroup from '../../../components/RadioGroup';
+
+const childrenRadio = {
+  code: `
+  <RadioGroup name="groceries" >
+  <RadioGroup.Radio value="Tomato sauce">
+    <span>Tomato Sauce</span><small> Good!</small>
+  </RadioGroup.Radio>
+  <RadioGroup.Radio value="Mustard">
+    <span>Mustard</span><small> Medium!</small>
+  </RadioGroup.Radio>
+  <RadioGroup.Radio value="Barbecue sauce">
+    <span>Barbecue sauce</span><small> really good!</small>
+  </RadioGroup.Radio>
+</RadioGroup>`,
+
+  component: (
+    <RadioGroup name="groceries">
+      <RadioGroup.Radio value="Tomato sauce">
+        <span>Tomato Sauce</span>
+        <small> Good!</small>
+      </RadioGroup.Radio>
+      <RadioGroup.Radio value="Mustard">
+        <span>Mustard</span>
+        <small> Medium!</small>
+      </RadioGroup.Radio>
+      <RadioGroup.Radio value="Barbecue sauce">
+        <span>Barbecue sauce</span>
+        <small> really good!</small>
+      </RadioGroup.Radio>
+    </RadioGroup>
+  ),
+};
+
+export default childrenRadio;

--- a/stories/RadioGroup/sub-components/index.jsx
+++ b/stories/RadioGroup/sub-components/index.jsx
@@ -5,6 +5,7 @@ import buttonGroup from './buttonGroup';
 import buttonGroupInline from './buttonGroupInline';
 import buttonGroupError from './buttonGroupError';
 import buttonGroupDisabled from './buttonGroupDisabled';
+import childrenRadio from './childrenRadio';
 
 export {
   simpleRadioGroup,
@@ -14,4 +15,5 @@ export {
   buttonGroupInline,
   buttonGroupError,
   buttonGroupDisabled,
+  childrenRadio,
 };


### PR DESCRIPTION
## Description

When we were using `<RadioGroup.Radio />` with HTML element inside that, this error in console occurred:

![Screen Shot 2020-03-13 at 11 26 33](https://user-images.githubusercontent.com/190265/76637478-bbba0a00-6542-11ea-9819-f7ade5306740.png)

This PR, adjust component to use `string` or elements inside `<RadioGroup.Radio />`

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation