### PR TITLE
feat(Card Thumbnail): implements native lazy load

### DIFF
--- a/components/Card/sub-components/Thumbnail.jsx
+++ b/components/Card/sub-components/Thumbnail.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { colors } from '../../shared/theme';
 
-const Image = styled.img`
+const Image = styled.img.attrs({ loading: 'lazy' })`
   border-radius: ${({ rounded }) => (rounded ? '50%' : '4px')};
   display: inline-block;
   height: 72px;


### PR DESCRIPTION
## Description
task: https://jirasoftware.catho.com.br/browse/QTM-178
Issue: https://github.com/catho/quantum/issues/130

⚠️ this new attribute only will show in the <img /> when the styled-components is updated.
In actual version `4.1.3`, this attribute did not exist and the styled removes the attributes that not recognise.
But, with this PR, when the styled-components is update, the attribute will show and works.

The problem in styled was solved here https://github.com/styled-components/styled-components/issues/2552

## Setup
to view the components behavior, run `yarn storybook`