### PR TITLE
fix(Icons): make a default icon size on pre loading

### DIFF
--- a/components/Accordion/__snapshots__/Accordion.unit.test.jsx.snap
+++ b/components/Accordion/__snapshots__/Accordion.unit.test.jsx.snap
@@ -42,7 +42,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
   box-sizing: content-box;
 }
 
-.c5 {
+.c6 {
   height: 0;
   -webkit-transform: scaleY(0);
   -ms-transform: scaleY(0);
@@ -57,29 +57,33 @@ exports[`Accordion component Should match the snapshot of a simple circular load
   font-size: 14px;
 }
 
-.c5 a {
+.c6 a {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 14px;
 }
 
-.c5 ul {
+.c6 ul {
   list-style-type: none;
   padding: 0;
 }
 
-.c5 ul > li {
+.c6 ul > li {
   padding: 8px 0;
 }
 
-.c5 p {
+.c6 p {
   margin: 0;
 }
 
 .c4 {
   font-size: 24px;
   line-height: inherit;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <ul
@@ -116,7 +120,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
       </span>
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4"
+        className="MuiSvgIcon-root c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -197,7 +201,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
     <div
       aria-hidden={true}
       aria-labelledby="Institucional-0-header"
-      className="c5"
+      className="c6"
       id="Institucional-0-content"
     >
       <ul>
@@ -270,7 +274,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
       </span>
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4"
+        className="MuiSvgIcon-root c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -351,7 +355,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
     <div
       aria-hidden={true}
       aria-labelledby="Para-candidato-1-header"
-      className="c5"
+      className="c6"
       id="Para-candidato-1-content"
     >
       <p>
@@ -400,7 +404,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
       </span>
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4"
+        className="MuiSvgIcon-root c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -481,7 +485,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
     <div
       aria-hidden={true}
       aria-labelledby="Para-Empresa-2-header"
-      className="c5"
+      className="c6"
       id="Para-Empresa-2-content"
     >
       <p>
@@ -530,7 +534,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
       </span>
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4"
+        className="MuiSvgIcon-root c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -611,7 +615,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
     <div
       aria-hidden={true}
       aria-labelledby="Educacao-3-header"
-      className="c5"
+      className="c6"
       id="Educacao-3-content"
     >
       <p>

--- a/components/Accordion/__snapshots__/Accordion.unit.test.jsx.snap
+++ b/components/Accordion/__snapshots__/Accordion.unit.test.jsx.snap
@@ -83,7 +83,7 @@ exports[`Accordion component Should match the snapshot of a simple circular load
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <ul

--- a/components/Alert/__snapshots__/Alert.unit.test.jsx.snap
+++ b/components/Alert/__snapshots__/Alert.unit.test.jsx.snap
@@ -141,7 +141,7 @@ exports[`Alert component Should match the snapshot of a simple alert 1`] = `
 }
 
 .c9 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -557,7 +557,7 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -986,7 +986,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 }
 
 .c9 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1415,7 +1415,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 }
 
 .c9 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1861,7 +1861,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 }
 
 .c9 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2324,7 +2324,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 }
 
 .c9 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2804,7 +2804,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 }
 
 .c9 {
-  width: 24px;
+  width: 0px;
 }
 
 <div

--- a/components/Alert/__snapshots__/Alert.unit.test.jsx.snap
+++ b/components/Alert/__snapshots__/Alert.unit.test.jsx.snap
@@ -123,7 +123,7 @@ exports[`Alert component Should match the snapshot of a simple alert 1`] = `
   padding: 12px 16px;
 }
 
-.c0 .c1 .c9 {
+.c0 .c1 .c10 {
   color: #424242;
   margin-right: 16px;
 }
@@ -138,6 +138,10 @@ exports[`Alert component Should match the snapshot of a simple alert 1`] = `
 .c0 .c1 > .c4 .c3 {
   color: #424242;
   margin-left: 0;
+}
+
+.c9 {
+  width: 24px;
 }
 
 <div
@@ -160,7 +164,7 @@ exports[`Alert component Should match the snapshot of a simple alert 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c7 c8"
+        className="MuiSvgIcon-root c7 c8 c9"
         focusable="false"
         role="presentation"
         style={
@@ -409,13 +413,13 @@ exports[`Alert component Should match the snapshot of a simple alert 1`] = `
 `;
 
 exports[`Alert component When you set a alert custom icon Should match the snapshot with an icon 1`] = `
-.c10 {
+.c11 {
   margin-right: 8px;
   pointer-events: none;
   width: 24px;
 }
 
-.c8 {
+.c9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -444,23 +448,23 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
   box-shadow: 0px 3px 1px -2px rgba(153,153,153,0.2),0px 2px 2px 0px rgba(153,153,153,0.14),0px 1px 5px 0px rgba(153,153,153,0.12);
 }
 
-.c8:hover {
+.c9:hover {
   box-shadow: 0px 2px 4px -1px rgba(25,25,25,0.2),0px 4px 5px 0px rgba(25,25,25,0.14),0px 1px 10px 0px rgba(25,25,25,0.12);
   background-color: #191919;
   border-color: #191919;
 }
 
-.c8:focus,
-.c8:focus-within {
+.c9:focus,
+.c9:focus-within {
   box-shadow: 0px 2px 4px -1px rgba(66,66,66,0.2),0px 4px 5px 0px rgba(66,66,66,0.14),0px 1px 10px 0px rgba(66,66,66,0.12);
 }
 
-.c8:active {
+.c9:active {
   box-shadow: 0px 5px 5px -3px rgba(25,25,25,0.2),0px 8px 10px 1px rgba(25,25,25,0.14),0px 3px 14px 2px rgba(25,25,25,0.12);
   background-color: #191919;
 }
 
-.c8 .c9 function (_ref6) {
+.c9 .c10 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -468,7 +472,7 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c8 .c9 function (_ref6) var fontSizes = {
+.c9 .c10 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -487,7 +491,7 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
   width: 24px;
 }
 
-.c7 {
+.c8 {
   border-radius: 50%;
   border: none;
   color: rgba(153,153,153,0.5);
@@ -503,24 +507,24 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
   width: auto;
 }
 
-.c7 .c9 {
+.c8 .c10 {
   margin-right: 0;
 }
 
-.c7:hover,
-.c7:focus {
+.c8:hover,
+.c8:focus {
   box-shadow: none;
   background-color: rgba(224,224,224,0.4);
   color: #424242;
 }
 
-.c7:active {
+.c8:active {
   box-shadow: none;
   background-color: rgba(224,224,224,0.5);
   color: #424242;
 }
 
-.c7:hover {
+.c8:hover {
   background: none;
   opacity: 1;
 }
@@ -540,16 +544,20 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
   margin-right: 16px;
 }
 
-.c0 .c1 > .c6 {
+.c0 .c1 > .c7 {
   color: #424242;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
-.c0 .c1 > .c6 .c5 {
+.c0 .c1 > .c7 .c6 {
   color: #424242;
   margin-left: 0;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -562,7 +570,7 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
   >
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c3 c4"
+      className="MuiSvgIcon-root c3 c4 c5"
       focusable="false"
       role="presentation"
       style={
@@ -581,7 +589,7 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
       Sample alert
     </span>
     <button
-      className="c5 c6 c7 c8"
+      className="c6 c7 c8 c9"
       disabled={false}
       onClick={[Function]}
       size="medium"
@@ -589,7 +597,7 @@ exports[`Alert component When you set a alert custom icon Should match the snaps
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c9 c10"
+        className="MuiSvgIcon-root c10 c11 c5"
         focusable="false"
         role="presentation"
         style={
@@ -960,7 +968,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   padding: 12px 16px;
 }
 
-.c0 .c1 .c9 {
+.c0 .c1 .c10 {
   color: #424242;
   margin-right: 16px;
 }
@@ -975,6 +983,10 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 .c0 .c1 > .c4 .c3 {
   color: #424242;
   margin-left: 0;
+}
+
+.c9 {
+  width: 24px;
 }
 
 <div
@@ -997,7 +1009,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c7 c8"
+        className="MuiSvgIcon-root c7 c8 c9"
         focusable="false"
         role="presentation"
         style={
@@ -1358,19 +1370,19 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   opacity: 1;
 }
 
-.c9 .c1 .c10 {
+.c10 .c1 .c11 {
   color: #424242;
   margin-right: 16px;
 }
 
-.c9 .c1 > .c4 {
+.c10 .c1 > .c4 {
   color: #424242;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
-.c9 .c1 > .c4 .c3 {
+.c10 .c1 > .c4 .c3 {
   color: #424242;
   margin-left: 0;
 }
@@ -1385,7 +1397,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   padding: 12px 16px;
 }
 
-.c0 .c1 .c10 {
+.c0 .c1 .c11 {
   color: #1250C4;
   margin-right: 16px;
 }
@@ -1400,6 +1412,10 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 .c0 .c1 > .c4 .c3 {
   color: #1250C4;
   margin-left: 0;
+}
+
+.c9 {
+  width: 24px;
 }
 
 <div
@@ -1422,7 +1438,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c7 c8"
+        className="MuiSvgIcon-root c7 c8 c9"
         focusable="false"
         role="presentation"
         style={
@@ -1783,36 +1799,36 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   opacity: 1;
 }
 
-.c9 .c1 .c11 {
+.c10 .c1 .c12 {
   color: #424242;
-  margin-right: 16px;
-}
-
-.c9 .c1 > .c4 {
-  color: #424242;
-  margin: 0 0 0 16px;
-  min-height: 0;
-  opacity: 1;
-}
-
-.c9 .c1 > .c4 .c3 {
-  color: #424242;
-  margin-left: 0;
-}
-
-.c10 .c1 .c11 {
-  color: #1250C4;
   margin-right: 16px;
 }
 
 .c10 .c1 > .c4 {
-  color: #1250C4;
+  color: #424242;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
 .c10 .c1 > .c4 .c3 {
+  color: #424242;
+  margin-left: 0;
+}
+
+.c11 .c1 .c12 {
+  color: #1250C4;
+  margin-right: 16px;
+}
+
+.c11 .c1 > .c4 {
+  color: #1250C4;
+  margin: 0 0 0 16px;
+  min-height: 0;
+  opacity: 1;
+}
+
+.c11 .c1 > .c4 .c3 {
   color: #1250C4;
   margin-left: 0;
 }
@@ -1827,7 +1843,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   padding: 12px 16px;
 }
 
-.c0 .c1 .c11 {
+.c0 .c1 .c12 {
   color: #3b610f;
   margin-right: 16px;
 }
@@ -1842,6 +1858,10 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 .c0 .c1 > .c4 .c3 {
   color: #3b610f;
   margin-left: 0;
+}
+
+.c9 {
+  width: 24px;
 }
 
 <div
@@ -1864,7 +1884,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c7 c8"
+        className="MuiSvgIcon-root c7 c8 c9"
         focusable="false"
         role="presentation"
         style={
@@ -2225,53 +2245,53 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   opacity: 1;
 }
 
-.c9 .c1 .c12 {
+.c10 .c1 .c13 {
   color: #424242;
-  margin-right: 16px;
-}
-
-.c9 .c1 > .c4 {
-  color: #424242;
-  margin: 0 0 0 16px;
-  min-height: 0;
-  opacity: 1;
-}
-
-.c9 .c1 > .c4 .c3 {
-  color: #424242;
-  margin-left: 0;
-}
-
-.c10 .c1 .c12 {
-  color: #1250C4;
   margin-right: 16px;
 }
 
 .c10 .c1 > .c4 {
-  color: #1250C4;
+  color: #424242;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
 .c10 .c1 > .c4 .c3 {
-  color: #1250C4;
+  color: #424242;
   margin-left: 0;
 }
 
-.c11 .c1 .c12 {
-  color: #3b610f;
+.c11 .c1 .c13 {
+  color: #1250C4;
   margin-right: 16px;
 }
 
 .c11 .c1 > .c4 {
-  color: #3b610f;
+  color: #1250C4;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
 .c11 .c1 > .c4 .c3 {
+  color: #1250C4;
+  margin-left: 0;
+}
+
+.c12 .c1 .c13 {
+  color: #3b610f;
+  margin-right: 16px;
+}
+
+.c12 .c1 > .c4 {
+  color: #3b610f;
+  margin: 0 0 0 16px;
+  min-height: 0;
+  opacity: 1;
+}
+
+.c12 .c1 > .c4 .c3 {
   color: #3b610f;
   margin-left: 0;
 }
@@ -2286,7 +2306,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   padding: 12px 16px;
 }
 
-.c0 .c1 .c12 {
+.c0 .c1 .c13 {
   color: #f09100;
   margin-right: 16px;
 }
@@ -2301,6 +2321,10 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 .c0 .c1 > .c4 .c3 {
   color: #f09100;
   margin-left: 0;
+}
+
+.c9 {
+  width: 24px;
 }
 
 <div
@@ -2323,7 +2347,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c7 c8"
+        className="MuiSvgIcon-root c7 c8 c9"
         focusable="false"
         role="presentation"
         style={
@@ -2684,70 +2708,70 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   opacity: 1;
 }
 
-.c9 .c1 .c13 {
+.c10 .c1 .c14 {
   color: #424242;
-  margin-right: 16px;
-}
-
-.c9 .c1 > .c4 {
-  color: #424242;
-  margin: 0 0 0 16px;
-  min-height: 0;
-  opacity: 1;
-}
-
-.c9 .c1 > .c4 .c3 {
-  color: #424242;
-  margin-left: 0;
-}
-
-.c10 .c1 .c13 {
-  color: #1250C4;
   margin-right: 16px;
 }
 
 .c10 .c1 > .c4 {
-  color: #1250C4;
+  color: #424242;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
 .c10 .c1 > .c4 .c3 {
-  color: #1250C4;
+  color: #424242;
   margin-left: 0;
 }
 
-.c11 .c1 .c13 {
-  color: #3b610f;
+.c11 .c1 .c14 {
+  color: #1250C4;
   margin-right: 16px;
 }
 
 .c11 .c1 > .c4 {
-  color: #3b610f;
+  color: #1250C4;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
 .c11 .c1 > .c4 .c3 {
-  color: #3b610f;
+  color: #1250C4;
   margin-left: 0;
 }
 
-.c12 .c1 .c13 {
-  color: #f09100;
+.c12 .c1 .c14 {
+  color: #3b610f;
   margin-right: 16px;
 }
 
 .c12 .c1 > .c4 {
-  color: #f09100;
+  color: #3b610f;
   margin: 0 0 0 16px;
   min-height: 0;
   opacity: 1;
 }
 
 .c12 .c1 > .c4 .c3 {
+  color: #3b610f;
+  margin-left: 0;
+}
+
+.c13 .c1 .c14 {
+  color: #f09100;
+  margin-right: 16px;
+}
+
+.c13 .c1 > .c4 {
+  color: #f09100;
+  margin: 0 0 0 16px;
+  min-height: 0;
+  opacity: 1;
+}
+
+.c13 .c1 > .c4 .c3 {
   color: #f09100;
   margin-left: 0;
 }
@@ -2762,7 +2786,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
   padding: 12px 16px;
 }
 
-.c0 .c1 .c13 {
+.c0 .c1 .c14 {
   color: #e91b0c;
   margin-right: 16px;
 }
@@ -2777,6 +2801,10 @@ exports[`Alert component When you set a different skin Should match a skin snaps
 .c0 .c1 > .c4 .c3 {
   color: #e91b0c;
   margin-left: 0;
+}
+
+.c9 {
+  width: 24px;
 }
 
 <div
@@ -2799,7 +2827,7 @@ exports[`Alert component When you set a different skin Should match a skin snaps
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c7 c8"
+        className="MuiSvgIcon-root c7 c8 c9"
         focusable="false"
         role="presentation"
         style={

--- a/components/Button/__snapshots__/Button.unit.test.jsx.snap
+++ b/components/Button/__snapshots__/Button.unit.test.jsx.snap
@@ -837,18 +837,6 @@ exports[`Button component with an icon should match secondary snapshot 1`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c3 .c1 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c3 .c1 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c4 .c1 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -909,6 +897,22 @@ exports[`Button component with an icon should match secondary snapshot 1`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
+.c9 .c1 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c9 .c1 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c3 {
+  width: 24px;
+}
+
 <button
   className="c0"
   disabled={false}
@@ -918,7 +922,7 @@ exports[`Button component with an icon should match secondary snapshot 1`] = `
 >
   <svg
     aria-hidden="true"
-    className="MuiSvgIcon-root c1 c2"
+    className="MuiSvgIcon-root c1 c2 c3"
     focusable="false"
     role="presentation"
     style={
@@ -1200,18 +1204,6 @@ exports[`Button component with an icon should match secondary snapshot 2`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c3 .c1 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c3 .c1 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c4 .c1 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -1272,6 +1264,22 @@ exports[`Button component with an icon should match secondary snapshot 2`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
+.c9 .c1 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c9 .c1 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c3 {
+  width: 24px;
+}
+
 <button
   className="c0"
   disabled={false}
@@ -1281,7 +1289,7 @@ exports[`Button component with an icon should match secondary snapshot 2`] = `
 >
   <svg
     aria-hidden="true"
-    className="MuiSvgIcon-root c1 c2"
+    className="MuiSvgIcon-root c1 c2 c3"
     focusable="false"
     role="presentation"
     style={
@@ -1563,18 +1571,6 @@ exports[`Button component with an icon should match secondary snapshot 3`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c3 .c1 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c3 .c1 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c4 .c1 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -1635,6 +1631,22 @@ exports[`Button component with an icon should match secondary snapshot 3`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
+.c9 .c1 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c9 .c1 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c3 {
+  width: 24px;
+}
+
 <button
   className="c0"
   disabled={false}
@@ -1644,7 +1656,7 @@ exports[`Button component with an icon should match secondary snapshot 3`] = `
 >
   <svg
     aria-hidden="true"
-    className="MuiSvgIcon-root c1 c2"
+    className="MuiSvgIcon-root c1 c2 c3"
     focusable="false"
     role="presentation"
     style={
@@ -1926,18 +1938,6 @@ exports[`Button component with an icon should match secondary snapshot 4`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c3 .c1 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c3 .c1 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c4 .c1 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -1998,6 +1998,22 @@ exports[`Button component with an icon should match secondary snapshot 4`] = `
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
+.c9 .c1 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c9 .c1 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c3 {
+  width: 24px;
+}
+
 <button
   className="c0"
   disabled={false}
@@ -2007,7 +2023,7 @@ exports[`Button component with an icon should match secondary snapshot 4`] = `
 >
   <svg
     aria-hidden="true"
-    className="MuiSvgIcon-root c1 c2"
+    className="MuiSvgIcon-root c1 c2 c3"
     focusable="false"
     role="presentation"
     style={

--- a/components/Button/__snapshots__/Button.unit.test.jsx.snap
+++ b/components/Button/__snapshots__/Button.unit.test.jsx.snap
@@ -910,7 +910,7 @@ exports[`Button component with an icon should match secondary snapshot 1`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <button
@@ -1277,7 +1277,7 @@ exports[`Button component with an icon should match secondary snapshot 2`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <button
@@ -1644,7 +1644,7 @@ exports[`Button component with an icon should match secondary snapshot 3`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <button
@@ -2011,7 +2011,7 @@ exports[`Button component with an icon should match secondary snapshot 4`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <button

--- a/components/Checkbox/__snapshots__/Checkbox.unit.test.jsx.snap
+++ b/components/Checkbox/__snapshots__/Checkbox.unit.test.jsx.snap
@@ -91,7 +91,7 @@ exports[`<Checkbox /> should match the snapshot 1`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -309,7 +309,7 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -531,7 +531,7 @@ exports[`<Checkbox /> should match the snapshot 3`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -742,7 +742,7 @@ exports[`<Checkbox /> should match the snapshot 4`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -949,7 +949,7 @@ exports[`<Checkbox /> should match the snapshot 5`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1156,7 +1156,7 @@ exports[`<Checkbox /> should match the snapshot 6`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1363,7 +1363,7 @@ exports[`<Checkbox /> should match the snapshot 7`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div

--- a/components/Checkbox/__snapshots__/Checkbox.unit.test.jsx.snap
+++ b/components/Checkbox/__snapshots__/Checkbox.unit.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`<Checkbox /> should match the snapshot 1`] = `
   margin-top: 4px;
 }
 
-.c4 {
+.c5 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
@@ -73,7 +73,7 @@ exports[`<Checkbox /> should match the snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c1[disabled] ~ .c3 {
+.c1[disabled] ~ .c4 {
   color: #999999;
 }
 
@@ -88,6 +88,10 @@ exports[`<Checkbox /> should match the snapshot 1`] = `
 
 .c1[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -108,7 +112,7 @@ exports[`<Checkbox /> should match the snapshot 1`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2 "
+      className="MuiSvgIcon-root c2 c3"
       focusable="false"
       role="presentation"
       style={
@@ -124,7 +128,7 @@ exports[`<Checkbox /> should match the snapshot 1`] = `
       />
     </svg>
     <label
-      className="c3 c4"
+      className="c4 c5"
       htmlFor=""
     >
       
@@ -135,7 +139,7 @@ exports[`<Checkbox /> should match the snapshot 1`] = `
 `;
 
 exports[`<Checkbox /> should match the snapshot 2`] = `
-.c5 {
+.c6 {
   color: #ac001a;
   margin-top: 8px;
   cursor: text;
@@ -155,14 +159,14 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
   margin-top: 4px;
 }
 
-.c4 {
+.c5 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
   margin: 0 0 0 12px;
 }
 
-.c6 + .c2 {
+.c7 + .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -188,32 +192,32 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
   font-size: 20px;
 }
 
-.c6:checked + .c2 {
+.c7:checked + .c2 {
   border-width: 0;
   background-color: #1250C4;
   color: #f2f2f2;
 }
 
-.c6:hover + .c2,
-.c6:focus + .c2 {
+.c7:hover + .c2,
+.c7:focus + .c2 {
   border-color: #1250C4;
   box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
 }
 
-.c6[disabled] ~ .c3 {
+.c7[disabled] ~ .c4 {
   color: #999999;
 }
 
-.c6[disabled] + .c2 {
+.c7[disabled] + .c2 {
   border-color: #999999;
   background-color: #e0e0e0;
 }
 
-.c6[disabled]:checked + .c2 {
+.c7[disabled]:checked + .c2 {
   background-color: #999999;
 }
 
-.c6[disabled]:hover + .c2 {
+.c7[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
@@ -287,7 +291,7 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
   cursor: not-allowed;
 }
 
-.c1[disabled] ~ .c3 {
+.c1[disabled] ~ .c4 {
   color: #999999;
 }
 
@@ -302,6 +306,10 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
 
 .c1[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -322,7 +330,7 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2 "
+      className="MuiSvgIcon-root c2 c3"
       focusable="false"
       role="presentation"
       style={
@@ -338,14 +346,14 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
       />
     </svg>
     <label
-      className="c3 c4"
+      className="c4 c5"
       htmlFor=""
     >
       
     </label>
   </div>
   <span
-    className="c5"
+    className="c6"
   >
     error message
   </span>
@@ -353,7 +361,7 @@ exports[`<Checkbox /> should match the snapshot 2`] = `
 `;
 
 exports[`<Checkbox /> should match the snapshot 3`] = `
-.c5 {
+.c6 {
   color: #ac001a;
   margin-top: 8px;
   cursor: text;
@@ -373,14 +381,14 @@ exports[`<Checkbox /> should match the snapshot 3`] = `
   margin-top: 4px;
 }
 
-.c4 {
+.c5 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
   margin: 0 0 0 12px;
 }
 
-.c6 + .c2 {
+.c7 + .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -406,32 +414,32 @@ exports[`<Checkbox /> should match the snapshot 3`] = `
   font-size: 20px;
 }
 
-.c6:checked + .c2 {
+.c7:checked + .c2 {
   border-width: 0;
   background-color: #1250C4;
   color: #f2f2f2;
 }
 
-.c6:hover + .c2,
-.c6:focus + .c2 {
+.c7:hover + .c2,
+.c7:focus + .c2 {
   border-color: #1250C4;
   box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
 }
 
-.c6[disabled] ~ .c3 {
+.c7[disabled] ~ .c4 {
   color: #999999;
 }
 
-.c6[disabled] + .c2 {
+.c7[disabled] + .c2 {
   border-color: #999999;
   background-color: #e0e0e0;
 }
 
-.c6[disabled]:checked + .c2 {
+.c7[disabled]:checked + .c2 {
   background-color: #999999;
 }
 
-.c6[disabled]:hover + .c2 {
+.c7[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
@@ -505,7 +513,7 @@ exports[`<Checkbox /> should match the snapshot 3`] = `
   cursor: not-allowed;
 }
 
-.c1[disabled] ~ .c3 {
+.c1[disabled] ~ .c4 {
   color: #999999;
 }
 
@@ -520,6 +528,10 @@ exports[`<Checkbox /> should match the snapshot 3`] = `
 
 .c1[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -540,7 +552,7 @@ exports[`<Checkbox /> should match the snapshot 3`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2 "
+      className="MuiSvgIcon-root c2 c3"
       focusable="false"
       role="presentation"
       style={
@@ -556,14 +568,14 @@ exports[`<Checkbox /> should match the snapshot 3`] = `
       />
     </svg>
     <label
-      className="c3 c4"
+      className="c4 c5"
       htmlFor=""
     >
       
     </label>
   </div>
   <span
-    className="c5"
+    className="c6"
   >
     error message
   </span>
@@ -580,7 +592,7 @@ exports[`<Checkbox /> should match the snapshot 4`] = `
   margin-top: 4px;
 }
 
-.c4 {
+.c5 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
@@ -643,7 +655,7 @@ exports[`<Checkbox /> should match the snapshot 4`] = `
   cursor: not-allowed;
 }
 
-.c1[disabled] ~ .c3 {
+.c1[disabled] ~ .c4 {
   color: #999999;
 }
 
@@ -660,7 +672,7 @@ exports[`<Checkbox /> should match the snapshot 4`] = `
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -686,47 +698,51 @@ exports[`<Checkbox /> should match the snapshot 4`] = `
   font-size: 20px;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   border-width: 0;
   background-color: #1250C4;
   color: #f2f2f2;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #1250C4;
   box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   border-color: #e91b0c;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   background-color: #e91b0c;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #e91b0c;
   box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
 }
 
-.c5[disabled] ~ .c3 {
+.c6[disabled] ~ .c4 {
   color: #999999;
 }
 
-.c5[disabled] + .c2 {
+.c6[disabled] + .c2 {
   border-color: #999999;
   background-color: #e0e0e0;
 }
 
-.c5[disabled]:checked + .c2 {
+.c6[disabled]:checked + .c2 {
   background-color: #999999;
 }
 
-.c5[disabled]:hover + .c2 {
+.c6[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -747,7 +763,7 @@ exports[`<Checkbox /> should match the snapshot 4`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2 "
+      className="MuiSvgIcon-root c2 c3"
       focusable="false"
       role="presentation"
       style={
@@ -763,7 +779,7 @@ exports[`<Checkbox /> should match the snapshot 4`] = `
       />
     </svg>
     <label
-      className="c3 c4"
+      className="c4 c5"
       htmlFor=""
     >
       
@@ -783,7 +799,7 @@ exports[`<Checkbox /> should match the snapshot 5`] = `
   margin-top: 4px;
 }
 
-.c4 {
+.c5 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
@@ -846,7 +862,7 @@ exports[`<Checkbox /> should match the snapshot 5`] = `
   cursor: not-allowed;
 }
 
-.c1[disabled] ~ .c3 {
+.c1[disabled] ~ .c4 {
   color: #999999;
 }
 
@@ -863,7 +879,7 @@ exports[`<Checkbox /> should match the snapshot 5`] = `
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -889,47 +905,51 @@ exports[`<Checkbox /> should match the snapshot 5`] = `
   font-size: 20px;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   border-width: 0;
   background-color: #1250C4;
   color: #f2f2f2;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #1250C4;
   box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   border-color: #e91b0c;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   background-color: #e91b0c;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #e91b0c;
   box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
 }
 
-.c5[disabled] ~ .c3 {
+.c6[disabled] ~ .c4 {
   color: #999999;
 }
 
-.c5[disabled] + .c2 {
+.c6[disabled] + .c2 {
   border-color: #999999;
   background-color: #e0e0e0;
 }
 
-.c5[disabled]:checked + .c2 {
+.c6[disabled]:checked + .c2 {
   background-color: #999999;
 }
 
-.c5[disabled]:hover + .c2 {
+.c6[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -950,7 +970,7 @@ exports[`<Checkbox /> should match the snapshot 5`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2 "
+      className="MuiSvgIcon-root c2 c3"
       focusable="false"
       role="presentation"
       style={
@@ -966,7 +986,7 @@ exports[`<Checkbox /> should match the snapshot 5`] = `
       />
     </svg>
     <label
-      className="c3 c4"
+      className="c4 c5"
       htmlFor=""
     >
       
@@ -986,7 +1006,7 @@ exports[`<Checkbox /> should match the snapshot 6`] = `
   margin-top: 4px;
 }
 
-.c4 {
+.c5 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
@@ -1049,7 +1069,7 @@ exports[`<Checkbox /> should match the snapshot 6`] = `
   cursor: not-allowed;
 }
 
-.c1[disabled] ~ .c3 {
+.c1[disabled] ~ .c4 {
   color: #999999;
 }
 
@@ -1066,7 +1086,7 @@ exports[`<Checkbox /> should match the snapshot 6`] = `
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1092,47 +1112,51 @@ exports[`<Checkbox /> should match the snapshot 6`] = `
   font-size: 20px;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   border-width: 0;
   background-color: #1250C4;
   color: #f2f2f2;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #1250C4;
   box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   border-color: #e91b0c;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   background-color: #e91b0c;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #e91b0c;
   box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
 }
 
-.c5[disabled] ~ .c3 {
+.c6[disabled] ~ .c4 {
   color: #999999;
 }
 
-.c5[disabled] + .c2 {
+.c6[disabled] + .c2 {
   border-color: #999999;
   background-color: #e0e0e0;
 }
 
-.c5[disabled]:checked + .c2 {
+.c6[disabled]:checked + .c2 {
   background-color: #999999;
 }
 
-.c5[disabled]:hover + .c2 {
+.c6[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -1153,7 +1177,7 @@ exports[`<Checkbox /> should match the snapshot 6`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2 "
+      className="MuiSvgIcon-root c2 c3"
       focusable="false"
       role="presentation"
       style={
@@ -1169,7 +1193,7 @@ exports[`<Checkbox /> should match the snapshot 6`] = `
       />
     </svg>
     <label
-      className="c3 c4"
+      className="c4 c5"
       htmlFor=""
     >
       Some text
@@ -1189,7 +1213,7 @@ exports[`<Checkbox /> should match the snapshot 7`] = `
   margin-top: 4px;
 }
 
-.c4 {
+.c5 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
@@ -1252,7 +1276,7 @@ exports[`<Checkbox /> should match the snapshot 7`] = `
   cursor: not-allowed;
 }
 
-.c1[disabled] ~ .c3 {
+.c1[disabled] ~ .c4 {
   color: #999999;
 }
 
@@ -1269,7 +1293,7 @@ exports[`<Checkbox /> should match the snapshot 7`] = `
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1295,47 +1319,51 @@ exports[`<Checkbox /> should match the snapshot 7`] = `
   font-size: 20px;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   border-width: 0;
   background-color: #1250C4;
   color: #f2f2f2;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #1250C4;
   box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
 }
 
-.c5 + .c2 {
+.c6 + .c2 {
   border-color: #e91b0c;
 }
 
-.c5:checked + .c2 {
+.c6:checked + .c2 {
   background-color: #e91b0c;
 }
 
-.c5:hover + .c2,
-.c5:focus + .c2 {
+.c6:hover + .c2,
+.c6:focus + .c2 {
   border-color: #e91b0c;
   box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
 }
 
-.c5[disabled] ~ .c3 {
+.c6[disabled] ~ .c4 {
   color: #999999;
 }
 
-.c5[disabled] + .c2 {
+.c6[disabled] + .c2 {
   border-color: #999999;
   background-color: #e0e0e0;
 }
 
-.c5[disabled]:checked + .c2 {
+.c6[disabled]:checked + .c2 {
   background-color: #999999;
 }
 
-.c5[disabled]:hover + .c2 {
+.c6[disabled]:hover + .c2 {
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -1356,7 +1384,7 @@ exports[`<Checkbox /> should match the snapshot 7`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2 "
+      className="MuiSvgIcon-root c2 c3"
       focusable="false"
       role="presentation"
       style={
@@ -1372,7 +1400,7 @@ exports[`<Checkbox /> should match the snapshot 7`] = `
       />
     </svg>
     <label
-      className="c3 c4"
+      className="c4 c5"
       htmlFor=""
     >
       

--- a/components/Checkbox/__snapshots__/CheckboxGroup.unit.test.jsx.snap
+++ b/components/Checkbox/__snapshots__/CheckboxGroup.unit.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`<CheckboxGroup /> snapshot should render the same 1`] = `
         />
         <svg
           aria-hidden=\\"true\\"
-          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR\\"
+          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 ctGxLY\\"
           focusable=\\"false\\"
           role=\\"presentation\\"
           style={
@@ -68,7 +68,7 @@ exports[`<CheckboxGroup /> snapshot should render the same 1`] = `
         />
         <svg
           aria-hidden=\\"true\\"
-          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR\\"
+          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 ctGxLY\\"
           focusable=\\"false\\"
           role=\\"presentation\\"
           style={
@@ -110,7 +110,7 @@ exports[`<CheckboxGroup /> snapshot should render the same 1`] = `
         />
         <svg
           aria-hidden=\\"true\\"
-          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR\\"
+          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 ctGxLY\\"
           focusable=\\"false\\"
           role=\\"presentation\\"
           style={
@@ -419,7 +419,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
   margin-top: 4px;
 }
 
-.c5 {
+.c6 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
@@ -482,7 +482,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
   cursor: not-allowed;
 }
 
-.c2[disabled] ~ .c4 {
+.c2[disabled] ~ .c5 {
   color: #999999;
 }
 
@@ -507,6 +507,10 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -528,7 +532,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -544,7 +548,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Foo
@@ -569,7 +573,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -585,7 +589,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Bar
@@ -610,7 +614,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -626,7 +630,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Baz
@@ -646,7 +650,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
   margin-top: 4px;
 }
 
-.c5 {
+.c6 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
@@ -709,7 +713,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
   cursor: not-allowed;
 }
 
-.c2[disabled] ~ .c4 {
+.c2[disabled] ~ .c5 {
   color: #999999;
 }
 
@@ -734,6 +738,10 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -755,7 +763,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -771,7 +779,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Foo
@@ -796,7 +804,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -812,7 +820,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Bar
@@ -837,7 +845,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -853,7 +861,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Baz
@@ -1101,18 +1109,6 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c7 .c4 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c7 .c4 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c8 .c4 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -1137,7 +1133,19 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c6 {
+.c10 .c4 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c10 .c4 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c7 {
   border: 0;
   height: 0;
   margin: 0;
@@ -1148,7 +1156,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
   width: 0;
 }
 
-.c1 .c10 {
+.c1 .c11 {
   font-size: 17px;
   margin-left: 8px;
 }
@@ -1169,6 +1177,10 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
   position: relative;
 }
 
+.c6 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -1186,7 +1198,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4 c5"
+        className="MuiSvgIcon-root c4 c5 c6"
         focusable="false"
         role="presentation"
         style={
@@ -1402,7 +1414,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
       </svg>
       <input
         checked={false}
-        className="c6"
+        className="c7"
         disabled={false}
         id="checkbox-button-18"
         name="Foo"
@@ -1428,7 +1440,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
       
       <input
         checked={false}
-        className="c6"
+        className="c7"
         disabled={false}
         id="checkbox-button-19"
         name="Bar"
@@ -1453,7 +1465,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4 c5"
+        className="MuiSvgIcon-root c4 c5 c6"
         focusable="false"
         role="presentation"
         style={
@@ -1669,7 +1681,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
       </svg>
       <input
         checked={false}
-        className="c6"
+        className="c7"
         disabled={false}
         id="checkbox-button-20"
         name="Baz"
@@ -1874,7 +1886,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with an error 
 `;
 
 exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled options 1`] = `
-.c6 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1903,23 +1915,23 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   box-shadow: 0px 3px 1px -2px rgba(153,153,153,0.2),0px 2px 2px 0px rgba(153,153,153,0.14),0px 1px 5px 0px rgba(153,153,153,0.12);
 }
 
-.c6:hover {
+.c7:hover {
   box-shadow: 0px 2px 4px -1px rgba(0,47,123,0.2),0px 4px 5px 0px rgba(0,47,123,0.14),0px 1px 10px 0px rgba(0,47,123,0.12);
   background-color: #E5EDFC;
   border-color: #002F7B;
 }
 
-.c6:focus,
-.c6:focus-within {
+.c7:focus,
+.c7:focus-within {
   box-shadow: 0px 2px 4px -1px rgba(18,80,196,0.2),0px 4px 5px 0px rgba(18,80,196,0.14),0px 1px 10px 0px rgba(18,80,196,0.12);
 }
 
-.c6:active {
+.c7:active {
   box-shadow: 0px 5px 5px -3px rgba(0,47,123,0.2),0px 8px 10px 1px rgba(0,47,123,0.14),0px 3px 14px 2px rgba(0,47,123,0.12);
   background-color: #E5EDFC;
 }
 
-.c6 .c8 function (_ref6) {
+.c7 .c9 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -1927,7 +1939,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c6 .c8 function (_ref6) var fontSizes = {
+.c7 .c9 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -1960,7 +1972,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   box-shadow: 0px 3px 1px -2px rgba(153,153,153,0.2),0px 2px 2px 0px rgba(153,153,153,0.14),0px 1px 5px 0px rgba(153,153,153,0.12);
 }
 
-.c3 .c8 function (_ref6) {
+.c3 .c9 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -1968,11 +1980,11 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c3 .c8 function (_ref6) var fontSizes = {
+.c3 .c9 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c7 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2001,7 +2013,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   box-shadow: 0px 3px 1px -2px rgba(153,153,153,0.2),0px 2px 2px 0px rgba(153,153,153,0.14),0px 1px 5px 0px rgba(153,153,153,0.12);
 }
 
-.c7 .c8 function (_ref6) {
+.c8 .c9 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -2009,7 +2021,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c7 .c8 function (_ref6) var fontSizes = {
+.c8 .c9 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -2045,6 +2057,10 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   position: relative;
 }
 
+.c6 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -2074,7 +2090,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
       Foo
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c5 "
+        className="MuiSvgIcon-root c5 c6"
         focusable="false"
         role="presentation"
         style={
@@ -2096,7 +2112,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   >
     <label
       checked={false}
-      className="c2 c6"
+      className="c2 c7"
       disabled={false}
       htmlFor="checkbox-button-10"
       onClick={[Function]}
@@ -2122,7 +2138,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
   >
     <label
       checked={true}
-      className="c2 c7"
+      className="c2 c8"
       disabled={true}
       htmlFor="checkbox-button-11"
       onClick={[Function]}
@@ -2143,7 +2159,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
       Baz
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c5 "
+        className="MuiSvgIcon-root c5 c6"
         focusable="false"
         role="presentation"
         style={
@@ -2164,7 +2180,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
 `;
 
 exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with an error 1`] = `
-.c6 {
+.c7 {
   color: #ac001a;
   margin-top: 8px;
   cursor: text;
@@ -2184,11 +2200,389 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with an erro
   margin-top: 4px;
 }
 
-.c5 {
+.c6 {
   display: block;
   margin-bottom: 5px;
   color: #424242;
   margin: 0 0 0 12px;
+}
+
+.c8 + .c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 2px;
+  box-sizing: border-box;
+  color: transparent;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-weight: bold;
+  height: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  width: 24px;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  font-size: 20px;
+}
+
+.c8:checked + .c3 {
+  border-width: 0;
+  background-color: #1250C4;
+  color: #f2f2f2;
+}
+
+.c8:hover + .c3,
+.c8:focus + .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c8[disabled] ~ .c5 {
+  color: #999999;
+}
+
+.c8[disabled] + .c3 {
+  border-color: #999999;
+  background-color: #e0e0e0;
+}
+
+.c8[disabled]:checked + .c3 {
+  background-color: #999999;
+}
+
+.c8[disabled]:hover + .c3 {
+  box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c2 {
+  border: 0;
+  height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 0;
+  cursor: pointer;
+  height: 100%;
+  width: 100%;
+}
+
+.c2 + .c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 2px;
+  box-sizing: border-box;
+  color: transparent;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-weight: bold;
+  height: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  width: 24px;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  font-size: 20px;
+}
+
+.c2:checked + .c3 {
+  border-width: 0;
+  background-color: #1250C4;
+  color: #f2f2f2;
+}
+
+.c2:hover + .c3,
+.c2:focus + .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c2 + .c3 {
+  border-color: #e91b0c;
+}
+
+.c2:checked + .c3 {
+  background-color: #e91b0c;
+}
+
+.c2:hover + .c3,
+.c2:focus + .c3 {
+  border-color: #e91b0c;
+  box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
+}
+
+.c2[disabled] {
+  cursor: not-allowed;
+}
+
+.c2[disabled] ~ .c5 {
+  color: #999999;
+}
+
+.c2[disabled] + .c3 {
+  border-color: #999999;
+  background-color: #e0e0e0;
+}
+
+.c2[disabled]:checked + .c3 {
+  background-color: #999999;
+}
+
+.c2[disabled]:hover + .c3 {
+  box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
+}
+
+.c0 {
+  position: relative;
+  margin-bottom: 20px;
+  min-width: 250px;
+  width: 100%;
+  position: relative;
+}
+
+.c4 {
+  width: 24px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className=""
+  >
+    <div
+      className="c1"
+    >
+      <input
+        checked={false}
+        className="c2"
+        disabled={false}
+        id=""
+        name="Foo"
+        onChange={[Function]}
+        type="checkbox"
+        value=""
+      />
+      <svg
+        aria-hidden="true"
+        className="MuiSvgIcon-root c3 c4"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "color": "",
+            "fontSize": 24,
+          }
+        }
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+        />
+      </svg>
+      <label
+        className="c5 c6"
+        htmlFor=""
+      >
+        Foo
+      </label>
+    </div>
+  </div>
+  <div
+    className=""
+  >
+    <div
+      className="c1"
+    >
+      <input
+        checked={false}
+        className="c2"
+        disabled={false}
+        id=""
+        name="Bar"
+        onChange={[Function]}
+        type="checkbox"
+        value=""
+      />
+      <svg
+        aria-hidden="true"
+        className="MuiSvgIcon-root c3 c4"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "color": "",
+            "fontSize": 24,
+          }
+        }
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+        />
+      </svg>
+      <label
+        className="c5 c6"
+        htmlFor=""
+      >
+        Bar
+      </label>
+    </div>
+  </div>
+  <div
+    className=""
+  >
+    <div
+      className="c1"
+    >
+      <input
+        checked={false}
+        className="c2"
+        disabled={false}
+        id=""
+        name="Baz"
+        onChange={[Function]}
+        type="checkbox"
+        value=""
+      />
+      <svg
+        aria-hidden="true"
+        className="MuiSvgIcon-root c3 c4"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "color": "",
+            "fontSize": 24,
+          }
+        }
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+        />
+      </svg>
+      <label
+        className="c5 c6"
+        htmlFor=""
+      >
+        Baz
+      </label>
+    </div>
+  </div>
+  <span
+    className="c7"
+  >
+    Error Message
+  </span>
+</div>
+`;
+
+exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disabled options 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  margin-top: 4px;
+}
+
+.c6 {
+  display: block;
+  margin-bottom: 5px;
+  color: #424242;
+  margin: 0 0 0 12px;
+}
+
+.c2 {
+  border: 0;
+  height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 0;
+  cursor: pointer;
+  height: 100%;
+  width: 100%;
+}
+
+.c2 + .c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 2px;
+  box-sizing: border-box;
+  color: transparent;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-weight: bold;
+  height: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  width: 24px;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  font-size: 20px;
+}
+
+.c2:checked + .c3 {
+  border-width: 0;
+  background-color: #1250C4;
+  color: #f2f2f2;
+}
+
+.c2:hover + .c3,
+.c2:focus + .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c2[disabled] {
+  cursor: not-allowed;
+}
+
+.c2[disabled] ~ .c5 {
+  color: #999999;
+}
+
+.c2[disabled] + .c3 {
+  border-color: #999999;
+  background-color: #e0e0e0;
+}
+
+.c2[disabled]:checked + .c3 {
+  background-color: #999999;
+}
+
+.c2[disabled]:hover + .c3 {
+  box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
 .c7 + .c3 {
@@ -2229,7 +2623,21 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with an erro
   box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
 }
 
-.c7[disabled] ~ .c4 {
+.c7 + .c3 {
+  border-color: #e91b0c;
+}
+
+.c7:checked + .c3 {
+  background-color: #e91b0c;
+}
+
+.c7:hover + .c3,
+.c7:focus + .c3 {
+  border-color: #e91b0c;
+  box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
+}
+
+.c7[disabled] ~ .c5 {
   color: #999999;
 }
 
@@ -2246,93 +2654,6 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with an erro
   box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
 }
 
-.c2 {
-  border: 0;
-  height: 0;
-  margin: 0;
-  opacity: 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 0;
-  cursor: pointer;
-  height: 100%;
-  width: 100%;
-}
-
-.c2 + .c3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  color: transparent;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-weight: bold;
-  height: 24px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: all 0.2s ease-in-out;
-  transition: all 0.2s ease-in-out;
-  width: 24px;
-  background-color: #ffffff;
-  border: 2px solid #999999;
-  font-size: 20px;
-}
-
-.c2:checked + .c3 {
-  border-width: 0;
-  background-color: #1250C4;
-  color: #f2f2f2;
-}
-
-.c2:hover + .c3,
-.c2:focus + .c3 {
-  border-color: #1250C4;
-  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
-}
-
-.c2 + .c3 {
-  border-color: #e91b0c;
-}
-
-.c2:checked + .c3 {
-  background-color: #e91b0c;
-}
-
-.c2:hover + .c3,
-.c2:focus + .c3 {
-  border-color: #e91b0c;
-  box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
-}
-
-.c2[disabled] {
-  cursor: not-allowed;
-}
-
-.c2[disabled] ~ .c4 {
-  color: #999999;
-}
-
-.c2[disabled] + .c3 {
-  border-color: #999999;
-  background-color: #e0e0e0;
-}
-
-.c2[disabled]:checked + .c3 {
-  background-color: #999999;
-}
-
-.c2[disabled]:hover + .c3 {
-  box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
-}
-
 .c0 {
   position: relative;
   margin-bottom: 20px;
@@ -2341,305 +2662,8 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with an erro
   position: relative;
 }
 
-<div
-  className="c0"
->
-  <div
-    className=""
-  >
-    <div
-      className="c1"
-    >
-      <input
-        checked={false}
-        className="c2"
-        disabled={false}
-        id=""
-        name="Foo"
-        onChange={[Function]}
-        type="checkbox"
-        value=""
-      />
-      <svg
-        aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
-        focusable="false"
-        role="presentation"
-        style={
-          Object {
-            "color": "",
-            "fontSize": 24,
-          }
-        }
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
-        />
-      </svg>
-      <label
-        className="c4 c5"
-        htmlFor=""
-      >
-        Foo
-      </label>
-    </div>
-  </div>
-  <div
-    className=""
-  >
-    <div
-      className="c1"
-    >
-      <input
-        checked={false}
-        className="c2"
-        disabled={false}
-        id=""
-        name="Bar"
-        onChange={[Function]}
-        type="checkbox"
-        value=""
-      />
-      <svg
-        aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
-        focusable="false"
-        role="presentation"
-        style={
-          Object {
-            "color": "",
-            "fontSize": 24,
-          }
-        }
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
-        />
-      </svg>
-      <label
-        className="c4 c5"
-        htmlFor=""
-      >
-        Bar
-      </label>
-    </div>
-  </div>
-  <div
-    className=""
-  >
-    <div
-      className="c1"
-    >
-      <input
-        checked={false}
-        className="c2"
-        disabled={false}
-        id=""
-        name="Baz"
-        onChange={[Function]}
-        type="checkbox"
-        value=""
-      />
-      <svg
-        aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
-        focusable="false"
-        role="presentation"
-        style={
-          Object {
-            "color": "",
-            "fontSize": 24,
-          }
-        }
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
-        />
-      </svg>
-      <label
-        className="c4 c5"
-        htmlFor=""
-      >
-        Baz
-      </label>
-    </div>
-  </div>
-  <span
-    className="c6"
-  >
-    Error Message
-  </span>
-</div>
-`;
-
-exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disabled options 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-  margin-top: 4px;
-}
-
-.c5 {
-  display: block;
-  margin-bottom: 5px;
-  color: #424242;
-  margin: 0 0 0 12px;
-}
-
-.c2 {
-  border: 0;
-  height: 0;
-  margin: 0;
-  opacity: 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 0;
-  cursor: pointer;
-  height: 100%;
-  width: 100%;
-}
-
-.c2 + .c3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  color: transparent;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-weight: bold;
-  height: 24px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: all 0.2s ease-in-out;
-  transition: all 0.2s ease-in-out;
+.c4 {
   width: 24px;
-  background-color: #ffffff;
-  border: 2px solid #999999;
-  font-size: 20px;
-}
-
-.c2:checked + .c3 {
-  border-width: 0;
-  background-color: #1250C4;
-  color: #f2f2f2;
-}
-
-.c2:hover + .c3,
-.c2:focus + .c3 {
-  border-color: #1250C4;
-  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
-}
-
-.c2[disabled] {
-  cursor: not-allowed;
-}
-
-.c2[disabled] ~ .c4 {
-  color: #999999;
-}
-
-.c2[disabled] + .c3 {
-  border-color: #999999;
-  background-color: #e0e0e0;
-}
-
-.c2[disabled]:checked + .c3 {
-  background-color: #999999;
-}
-
-.c2[disabled]:hover + .c3 {
-  box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
-}
-
-.c6 + .c3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2px;
-  box-sizing: border-box;
-  color: transparent;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-weight: bold;
-  height: 24px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-transition: all 0.2s ease-in-out;
-  transition: all 0.2s ease-in-out;
-  width: 24px;
-  background-color: #ffffff;
-  border: 2px solid #999999;
-  font-size: 20px;
-}
-
-.c6:checked + .c3 {
-  border-width: 0;
-  background-color: #1250C4;
-  color: #f2f2f2;
-}
-
-.c6:hover + .c3,
-.c6:focus + .c3 {
-  border-color: #1250C4;
-  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
-}
-
-.c6 + .c3 {
-  border-color: #e91b0c;
-}
-
-.c6:checked + .c3 {
-  background-color: #e91b0c;
-}
-
-.c6:hover + .c3,
-.c6:focus + .c3 {
-  border-color: #e91b0c;
-  box-shadow: 0px 3px 5px -1px rgba(233,27,12,0.2),0px 5px 8px 0px rgba(233,27,12,0.14),0px 1px 14px 0px rgba(233,27,12,0.12);
-}
-
-.c6[disabled] ~ .c4 {
-  color: #999999;
-}
-
-.c6[disabled] + .c3 {
-  border-color: #999999;
-  background-color: #e0e0e0;
-}
-
-.c6[disabled]:checked + .c3 {
-  background-color: #999999;
-}
-
-.c6[disabled]:hover + .c3 {
-  box-shadow: 0px 0px 0px 0px rgba(66,66,66,0.2),0px 0px 0px 0px rgba(66,66,66,0.14),0px 0px 0px 0px rgba(66,66,66,0.12);
-}
-
-.c0 {
-  position: relative;
-  margin-bottom: 20px;
-  min-width: 250px;
-  width: 100%;
-  position: relative;
 }
 
 <div
@@ -2663,7 +2687,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disable
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -2679,7 +2703,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disable
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Foo
@@ -2704,7 +2728,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disable
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -2720,7 +2744,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disable
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Bar
@@ -2745,7 +2769,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disable
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 "
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -2761,7 +2785,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disable
         />
       </svg>
       <label
-        className="c4 c5"
+        className="c5 c6"
         htmlFor=""
       >
         Baz

--- a/components/Checkbox/__snapshots__/CheckboxGroup.unit.test.jsx.snap
+++ b/components/Checkbox/__snapshots__/CheckboxGroup.unit.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`<CheckboxGroup /> snapshot should render the same 1`] = `
         />
         <svg
           aria-hidden=\\"true\\"
-          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 ctGxLY\\"
+          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 laLqyS\\"
           focusable=\\"false\\"
           role=\\"presentation\\"
           style={
@@ -68,7 +68,7 @@ exports[`<CheckboxGroup /> snapshot should render the same 1`] = `
         />
         <svg
           aria-hidden=\\"true\\"
-          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 ctGxLY\\"
+          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 laLqyS\\"
           focusable=\\"false\\"
           role=\\"presentation\\"
           style={
@@ -110,7 +110,7 @@ exports[`<CheckboxGroup /> snapshot should render the same 1`] = `
         />
         <svg
           aria-hidden=\\"true\\"
-          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 ctGxLY\\"
+          className=\\"MuiSvgIcon-root Checkbox__CheckIcon-sc-1ca5whm-3 cYUJOR Icon__SelectedIcon-mfzsxw-0 laLqyS\\"
           focusable=\\"false\\"
           role=\\"presentation\\"
           style={
@@ -508,7 +508,7 @@ exports[`<CheckboxGroup /> snapshot simple with <CheckboxGroup.Checkbox /> 1`] =
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -739,7 +739,7 @@ exports[`<CheckboxGroup /> snapshot simple with options 1`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1178,7 +1178,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> and icons 1`] 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2058,7 +2058,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Button /> with disabled 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2358,7 +2358,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with an erro
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2663,7 +2663,7 @@ exports[`<CheckboxGroup /> snapshot with <CheckboxGroup.Checkbox /> with disable
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div

--- a/components/Dropdown/__snapshots__/Dropdown.unit.test.jsx.snap
+++ b/components/Dropdown/__snapshots__/Dropdown.unit.test.jsx.snap
@@ -88,7 +88,7 @@ exports[`Dropdown component  should match the snapshot 1`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -306,7 +306,7 @@ exports[`Dropdown component  should match the snapshot 2`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -527,7 +527,7 @@ exports[`Dropdown component  should match the snapshot 3`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -757,7 +757,7 @@ exports[`Dropdown component  should match the snapshot 4`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -979,7 +979,7 @@ exports[`Dropdown component  should match the snapshot 5`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1203,7 +1203,7 @@ exports[`Dropdown component  should match the snapshot 6`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1438,7 +1438,7 @@ exports[`Dropdown component  should match the snapshot 7`] = `
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1673,7 +1673,7 @@ exports[`Dropdown component  should match the snapshot 8`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1900,7 +1900,7 @@ exports[`Dropdown component  should match the snapshot 9`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2118,7 +2118,7 @@ exports[`Dropdown component  should match the snapshot 10`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2342,7 +2342,7 @@ exports[`Dropdown component  should match the snapshot 11`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2567,7 +2567,7 @@ exports[`Dropdown component  should match the snapshot 12`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div

--- a/components/Dropdown/__snapshots__/Dropdown.unit.test.jsx.snap
+++ b/components/Dropdown/__snapshots__/Dropdown.unit.test.jsx.snap
@@ -87,6 +87,10 @@ exports[`Dropdown component  should match the snapshot 1`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -130,7 +134,7 @@ exports[`Dropdown component  should match the snapshot 1`] = `
       Select an option
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -301,6 +305,10 @@ exports[`Dropdown component  should match the snapshot 2`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -344,7 +352,7 @@ exports[`Dropdown component  should match the snapshot 2`] = `
       Dropdown placeholder
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -518,6 +526,10 @@ exports[`Dropdown component  should match the snapshot 3`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -561,7 +573,7 @@ exports[`Dropdown component  should match the snapshot 3`] = `
       
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -653,7 +665,7 @@ exports[`Dropdown component  should match the snapshot 4`] = `
   width: 100%;
 }
 
-.c4 {
+.c5 {
   color: #ac001a;
   margin-top: 8px;
   cursor: text;
@@ -744,6 +756,10 @@ exports[`Dropdown component  should match the snapshot 4`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -787,7 +803,7 @@ exports[`Dropdown component  should match the snapshot 4`] = `
       Select an option
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -868,7 +884,7 @@ exports[`Dropdown component  should match the snapshot 4`] = `
   </div>
   
   <span
-    className="c4"
+    className="c5"
   >
     Error message
   </span>
@@ -962,6 +978,10 @@ exports[`Dropdown component  should match the snapshot 5`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -1005,7 +1025,7 @@ exports[`Dropdown component  should match the snapshot 5`] = `
       Select an option
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -1182,6 +1202,10 @@ exports[`Dropdown component  should match the snapshot 6`] = `
   position: relative;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -1232,7 +1256,7 @@ exports[`Dropdown component  should match the snapshot 6`] = `
       Select an option
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4"
+        className="MuiSvgIcon-root c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1413,6 +1437,10 @@ exports[`Dropdown component  should match the snapshot 7`] = `
   position: relative;
 }
 
+.c6 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -1468,7 +1496,7 @@ exports[`Dropdown component  should match the snapshot 7`] = `
       Select an option
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c5"
+        className="MuiSvgIcon-root c5 c6"
         focusable="false"
         role="presentation"
         style={
@@ -1644,6 +1672,10 @@ exports[`Dropdown component  should match the snapshot 8`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -1696,7 +1728,7 @@ exports[`Dropdown component  should match the snapshot 8`] = `
       />
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -1867,6 +1899,10 @@ exports[`Dropdown component  should match the snapshot 9`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -1910,7 +1946,7 @@ exports[`Dropdown component  should match the snapshot 9`] = `
       Select an option
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -2081,6 +2117,10 @@ exports[`Dropdown component  should match the snapshot 10`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -2124,7 +2164,7 @@ exports[`Dropdown component  should match the snapshot 10`] = `
       baz
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={
@@ -2301,6 +2341,10 @@ exports[`Dropdown component  should match the snapshot 11`] = `
   position: relative;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -2351,7 +2395,7 @@ exports[`Dropdown component  should match the snapshot 11`] = `
       What credit card do you prefer?
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c4"
+        className="MuiSvgIcon-root c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -2522,6 +2566,10 @@ exports[`Dropdown component  should match the snapshot 12`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -2565,7 +2613,7 @@ exports[`Dropdown component  should match the snapshot 12`] = `
       Select an option
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3"
+        className="MuiSvgIcon-root c3 c4"
         focusable="false"
         role="presentation"
         style={

--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import AccessibleForward from '@material-ui/icons/AccessibleForward';
 import Add from '@material-ui/icons/Add';
 import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
@@ -116,7 +117,9 @@ const Icon = ({ name, skin, size, ...props }) => {
 
   if (!components[name]) return <span>{name}</span>;
 
-  const SelectedIcon = components[name];
+  const SelectedIcon = styled(components[name])`
+    width: 24px;
+  `;
 
   return (
     <SelectedIcon {...props} style={{ color: skin, fontSize: sizes[size] }}>

--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -118,7 +118,7 @@ const Icon = ({ name, skin, size, ...props }) => {
   if (!components[name]) return <span>{name}</span>;
 
   const SelectedIcon = styled(components[name])`
-    width: 24px;
+    width: 0px;
   `;
 
   return (

--- a/components/Icon/__snapshots__/Icon.unit.test.jsx.snap
+++ b/components/Icon/__snapshots__/Icon.unit.test.jsx.snap
@@ -1,9 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Icon /> Should match the snapshot 1`] = `
+.c0 {
+  width: 24px;
+}
+
 <svg
   aria-hidden="true"
-  className="MuiSvgIcon-root"
+  className="MuiSvgIcon-root c0"
   focusable="false"
   role="presentation"
   style={
@@ -26,9 +30,13 @@ exports[`<Icon /> Should match the snapshot 1`] = `
 `;
 
 exports[`<Icon /> Should match the snapshot 2`] = `
+.c0 {
+  width: 24px;
+}
+
 <svg
   aria-hidden="true"
-  className="MuiSvgIcon-root"
+  className="MuiSvgIcon-root c0"
   focusable="false"
   role="presentation"
   style={
@@ -46,9 +54,13 @@ exports[`<Icon /> Should match the snapshot 2`] = `
 `;
 
 exports[`<Icon /> Should match the snapshot 3`] = `
+.c0 {
+  width: 24px;
+}
+
 <svg
   aria-hidden="true"
-  className="MuiSvgIcon-root"
+  className="MuiSvgIcon-root c0"
   focusable="false"
   role="presentation"
   style={
@@ -66,9 +78,13 @@ exports[`<Icon /> Should match the snapshot 3`] = `
 `;
 
 exports[`<Icon /> Should match the snapshot 4`] = `
+.c0 {
+  width: 24px;
+}
+
 <svg
   aria-hidden="true"
-  className="MuiSvgIcon-root"
+  className="MuiSvgIcon-root c0"
   focusable="false"
   role="presentation"
   style={
@@ -86,9 +102,13 @@ exports[`<Icon /> Should match the snapshot 4`] = `
 `;
 
 exports[`<Icon /> Should match the snapshot 5`] = `
+.c0 {
+  width: 24px;
+}
+
 <svg
   aria-hidden="true"
-  className="MuiSvgIcon-root"
+  className="MuiSvgIcon-root c0"
   focusable="false"
   role="presentation"
   style={
@@ -106,9 +126,13 @@ exports[`<Icon /> Should match the snapshot 5`] = `
 `;
 
 exports[`<Icon /> Should match the snapshot 6`] = `
+.c0 {
+  width: 24px;
+}
+
 <svg
   aria-hidden="true"
-  className="MuiSvgIcon-root"
+  className="MuiSvgIcon-root c0"
   focusable="false"
   role="presentation"
   style={
@@ -126,9 +150,13 @@ exports[`<Icon /> Should match the snapshot 6`] = `
 `;
 
 exports[`<Icon /> Should match the snapshot 7`] = `
+.c0 {
+  width: 24px;
+}
+
 <svg
   aria-hidden="true"
-  className="MuiSvgIcon-root"
+  className="MuiSvgIcon-root c0"
   focusable="false"
   role="presentation"
   style={

--- a/components/Icon/__snapshots__/Icon.unit.test.jsx.snap
+++ b/components/Icon/__snapshots__/Icon.unit.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Icon /> Should match the snapshot 1`] = `
 .c0 {
-  width: 24px;
+  width: 0px;
 }
 
 <svg
@@ -31,7 +31,7 @@ exports[`<Icon /> Should match the snapshot 1`] = `
 
 exports[`<Icon /> Should match the snapshot 2`] = `
 .c0 {
-  width: 24px;
+  width: 0px;
 }
 
 <svg
@@ -55,7 +55,7 @@ exports[`<Icon /> Should match the snapshot 2`] = `
 
 exports[`<Icon /> Should match the snapshot 3`] = `
 .c0 {
-  width: 24px;
+  width: 0px;
 }
 
 <svg
@@ -79,7 +79,7 @@ exports[`<Icon /> Should match the snapshot 3`] = `
 
 exports[`<Icon /> Should match the snapshot 4`] = `
 .c0 {
-  width: 24px;
+  width: 0px;
 }
 
 <svg
@@ -103,7 +103,7 @@ exports[`<Icon /> Should match the snapshot 4`] = `
 
 exports[`<Icon /> Should match the snapshot 5`] = `
 .c0 {
-  width: 24px;
+  width: 0px;
 }
 
 <svg
@@ -127,7 +127,7 @@ exports[`<Icon /> Should match the snapshot 5`] = `
 
 exports[`<Icon /> Should match the snapshot 6`] = `
 .c0 {
-  width: 24px;
+  width: 0px;
 }
 
 <svg
@@ -151,7 +151,7 @@ exports[`<Icon /> Should match the snapshot 6`] = `
 
 exports[`<Icon /> Should match the snapshot 7`] = `
 .c0 {
-  width: 24px;
+  width: 0px;
 }
 
 <svg

--- a/components/Input/__snapshots__/Input.mask.unit.test.jsx.snap
+++ b/components/Input/__snapshots__/Input.mask.unit.test.jsx.snap
@@ -61,7 +61,7 @@ exports[`Input component should match snapshots 2`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -256,7 +256,7 @@ exports[`Input component should match snapshots 4`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -433,7 +433,7 @@ exports[`Input component should match snapshots 6`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -722,7 +722,7 @@ exports[`Input component should match snapshots 10`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1161,7 +1161,7 @@ exports[`Input component should match snapshots 17`] = `
 }
 
 .c3 {
-  width: 24px;
+  width: 0px;
 }
 
 <div

--- a/components/Input/__snapshots__/Input.mask.unit.test.jsx.snap
+++ b/components/Input/__snapshots__/Input.mask.unit.test.jsx.snap
@@ -60,6 +60,10 @@ exports[`Input component should match snapshots 2`] = `
   position: relative;
 }
 
+.c3 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -83,7 +87,7 @@ exports[`Input component should match snapshots 2`] = `
     
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2"
+      className="MuiSvgIcon-root c2 c3"
       description=""
       focusable="false"
       onClick={[Function]}
@@ -227,7 +231,7 @@ exports[`Input component should match snapshots 4`] = `
   width: 100%;
 }
 
-.c3 {
+.c4 {
   color: #ac001a;
   margin-top: 8px;
   cursor: text;
@@ -249,6 +253,10 @@ exports[`Input component should match snapshots 4`] = `
 
 .c1 {
   position: relative;
+}
+
+.c3 {
+  width: 24px;
 }
 
 <div
@@ -273,7 +281,7 @@ exports[`Input component should match snapshots 4`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2"
+      className="MuiSvgIcon-root c2 c3"
       description=""
       focusable="false"
       role="presentation"
@@ -355,7 +363,7 @@ exports[`Input component should match snapshots 4`] = `
   </div>
   
   <span
-    className="c3"
+    className="c4"
   >
     Error message
   </span>
@@ -424,6 +432,10 @@ exports[`Input component should match snapshots 6`] = `
   position: relative;
 }
 
+.c3 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -434,7 +446,7 @@ exports[`Input component should match snapshots 6`] = `
   >
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2"
+      className="MuiSvgIcon-root c2 c3"
       description=""
       focusable="false"
       role="presentation"
@@ -709,6 +721,10 @@ exports[`Input component should match snapshots 10`] = `
   position: relative;
 }
 
+.c4 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -723,7 +739,7 @@ exports[`Input component should match snapshots 10`] = `
   >
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c3"
+      className="MuiSvgIcon-root c3 c4"
       description="this is a description label"
       focusable="false"
       role="presentation"
@@ -1144,6 +1160,10 @@ exports[`Input component should match snapshots 17`] = `
   position: relative;
 }
 
+.c3 {
+  width: 24px;
+}
+
 <div
   className="c0"
 >
@@ -1167,7 +1187,7 @@ exports[`Input component should match snapshots 17`] = `
     
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c2"
+      className="MuiSvgIcon-root c2 c3"
       description=""
       focusable="false"
       onClick={[Function]}

--- a/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
+++ b/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
@@ -184,6 +184,10 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   width: 100vw;
 }
 
+.c14 {
+  width: 24px;
+}
+
 @media (min-width:0px) {
   .c1 {
     width: 90%;
@@ -595,6 +599,10 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
   width: 100vw;
 }
 
+.c14 {
+  width: 24px;
+}
+
 @media (min-width:0px) {
   .c1 {
     width: 90%;
@@ -657,7 +665,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root c12 c13"
+                class="MuiSvgIcon-root c12 c13 c14"
                 focusable="false"
                 role="presentation"
                 style="font-size: 24px;"
@@ -940,7 +948,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root c12 c13"
+                    class="MuiSvgIcon-root c12 c13 c14"
                     focusable="false"
                     role="presentation"
                     style="font-size: 24px;"
@@ -4652,7 +4660,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                           }
                                         }
                                       >
-                                        <ForwardRef
+                                        <Icon__SelectedIcon
                                           className="c12 c13"
                                           style={
                                             Object {
@@ -4859,8 +4867,42 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                             }
                                           }
                                         >
-                                          <WithStyles(ForwardRef(SvgIcon))
+                                          <StyledComponent
                                             className="c12 c13"
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "attrs": Array [],
+                                                "compare": null,
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                                  "isStatic": true,
+                                                  "lastClassName": "c14",
+                                                  "rules": Array [
+                                                    "width:24px;",
+                                                  ],
+                                                },
+                                                "displayName": "Icon__SelectedIcon",
+                                                "foldedComponentIds": Array [],
+                                                "muiName": "SvgIcon",
+                                                "render": [Function],
+                                                "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                                "target": Object {
+                                                  "$$typeof": Symbol(react.memo),
+                                                  "compare": null,
+                                                  "displayName": "CloseIcon",
+                                                  "muiName": "SvgIcon",
+                                                  "type": Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  },
+                                                },
+                                                "toString": [Function],
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={null}
                                             style={
                                               Object {
                                                 "color": "",
@@ -5066,21 +5108,8 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                               }
                                             }
                                           >
-                                            <ForwardRef(SvgIcon)
-                                              className="c12 c13"
-                                              classes={
-                                                Object {
-                                                  "colorAction": "MuiSvgIcon-colorAction",
-                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                  "colorError": "MuiSvgIcon-colorError",
-                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                  "root": "MuiSvgIcon-root",
-                                                }
-                                              }
+                                            <ForwardRef
+                                              className="c12 c13 c14"
                                               style={
                                                 Object {
                                                   "color": "",
@@ -5286,11 +5315,8 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                                 }
                                               }
                                             >
-                                              <svg
-                                                aria-hidden="true"
-                                                className="MuiSvgIcon-root c12 c13"
-                                                focusable="false"
-                                                role="presentation"
+                                              <WithStyles(ForwardRef(SvgIcon))
+                                                className="c12 c13 c14"
                                                 style={
                                                   Object {
                                                     "color": "",
@@ -5495,15 +5521,447 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                                     },
                                                   }
                                                 }
-                                                viewBox="0 0 24 24"
                                               >
-                                                <path
-                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                                />
-                                              </svg>
-                                            </ForwardRef(SvgIcon)>
-                                          </WithStyles(ForwardRef(SvgIcon))>
-                                        </ForwardRef>
+                                                <ForwardRef(SvgIcon)
+                                                  className="c12 c13 c14"
+                                                  classes={
+                                                    Object {
+                                                      "colorAction": "MuiSvgIcon-colorAction",
+                                                      "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                      "colorError": "MuiSvgIcon-colorError",
+                                                      "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                      "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                      "root": "MuiSvgIcon-root",
+                                                    }
+                                                  }
+                                                  style={
+                                                    Object {
+                                                      "color": "",
+                                                      "fontSize": 24,
+                                                    }
+                                                  }
+                                                  theme={
+                                                    Object {
+                                                      "breakpoints": Object {
+                                                        "large": Object {
+                                                          "columns": 12,
+                                                          "width": 1440,
+                                                        },
+                                                        "medium": Object {
+                                                          "columns": 12,
+                                                          "width": 1024,
+                                                        },
+                                                        "small": Object {
+                                                          "columns": 8,
+                                                          "width": 600,
+                                                        },
+                                                        "xlarge": Object {
+                                                          "columns": 12,
+                                                          "width": 1920,
+                                                        },
+                                                        "xsmall": Object {
+                                                          "columns": 4,
+                                                        },
+                                                      },
+                                                      "colors": Object {
+                                                        "error": Object {
+                                                          "100": "#fff5f5",
+                                                          "300": "#f88e86",
+                                                          "500": "#ec584e",
+                                                          "700": "#e91b0c",
+                                                          "900": "#ac001a",
+                                                        },
+                                                        "neutral": Object {
+                                                          "0": "#ffffff",
+                                                          "100": "#f2f2f2",
+                                                          "1000": "#000000",
+                                                          "300": "#e0e0e0",
+                                                          "500": "#999999",
+                                                          "700": "#424242",
+                                                          "900": "#191919",
+                                                        },
+                                                        "primary": Object {
+                                                          "100": "#E5EDFC",
+                                                          "300": "#89AAE7",
+                                                          "500": "#0CC0EA",
+                                                          "700": "#1250C4",
+                                                          "900": "#002F7B",
+                                                        },
+                                                        "secondary": Object {
+                                                          "100": "#F7B0C8",
+                                                          "300": "#F278A1",
+                                                          "500": "#E91E63",
+                                                          "700": "#DE0059",
+                                                          "900": "#9E003F",
+                                                        },
+                                                        "success": Object {
+                                                          "100": "#dcedc8",
+                                                          "300": "#c9eda2",
+                                                          "500": "#7ed321",
+                                                          "700": "#3b610f",
+                                                          "900": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "100": "#ffefd6",
+                                                          "300": "#ffda6a",
+                                                          "500": "#ffc107",
+                                                          "700": "#f09100",
+                                                          "900": "#d14900",
+                                                        },
+                                                      },
+                                                      "components": Object {
+                                                        "button": Object {
+                                                          "skins": Object {
+                                                            "error": Object {
+                                                              "mainColor": Object {
+                                                                "100": "#fff5f5",
+                                                                "300": "#f88e86",
+                                                                "500": "#ec584e",
+                                                                "700": "#e91b0c",
+                                                                "900": "#ac001a",
+                                                              },
+                                                              "text": Object {
+                                                                "0": "#ffffff",
+                                                                "100": "#f2f2f2",
+                                                                "1000": "#000000",
+                                                                "300": "#e0e0e0",
+                                                                "500": "#999999",
+                                                                "700": "#424242",
+                                                                "900": "#191919",
+                                                              },
+                                                            },
+                                                            "neutral": Object {
+                                                              "mainColor": Object {
+                                                                "0": "#ffffff",
+                                                                "100": "#f2f2f2",
+                                                                "1000": "#000000",
+                                                                "300": "#e0e0e0",
+                                                                "500": "#999999",
+                                                                "700": "#424242",
+                                                                "900": "#191919",
+                                                              },
+                                                              "text": Object {
+                                                                "0": "#ffffff",
+                                                                "100": "#f2f2f2",
+                                                                "1000": "#000000",
+                                                                "300": "#e0e0e0",
+                                                                "500": "#999999",
+                                                                "700": "#424242",
+                                                                "900": "#191919",
+                                                              },
+                                                            },
+                                                            "primary": Object {
+                                                              "mainColor": Object {
+                                                                "100": "#E5EDFC",
+                                                                "300": "#89AAE7",
+                                                                "500": "#0CC0EA",
+                                                                "700": "#1250C4",
+                                                                "900": "#002F7B",
+                                                              },
+                                                              "text": Object {
+                                                                "0": "#ffffff",
+                                                                "100": "#f2f2f2",
+                                                                "1000": "#000000",
+                                                                "300": "#e0e0e0",
+                                                                "500": "#999999",
+                                                                "700": "#424242",
+                                                                "900": "#191919",
+                                                              },
+                                                            },
+                                                            "secondary": Object {
+                                                              "mainColor": Object {
+                                                                "100": "#F7B0C8",
+                                                                "300": "#F278A1",
+                                                                "500": "#E91E63",
+                                                                "700": "#DE0059",
+                                                                "900": "#9E003F",
+                                                              },
+                                                              "text": Object {
+                                                                "0": "#ffffff",
+                                                                "100": "#f2f2f2",
+                                                                "1000": "#000000",
+                                                                "300": "#e0e0e0",
+                                                                "500": "#999999",
+                                                                "700": "#424242",
+                                                                "900": "#191919",
+                                                              },
+                                                            },
+                                                            "success": Object {
+                                                              "mainColor": Object {
+                                                                "100": "#dcedc8",
+                                                                "300": "#c9eda2",
+                                                                "500": "#7ed321",
+                                                                "700": "#3b610f",
+                                                                "900": "#004D40",
+                                                              },
+                                                              "text": Object {
+                                                                "0": "#ffffff",
+                                                                "100": "#f2f2f2",
+                                                                "1000": "#000000",
+                                                                "300": "#e0e0e0",
+                                                                "500": "#999999",
+                                                                "700": "#424242",
+                                                                "900": "#191919",
+                                                              },
+                                                            },
+                                                            "warning": Object {
+                                                              "mainColor": Object {
+                                                                "100": "#ffefd6",
+                                                                "300": "#ffda6a",
+                                                                "500": "#ffc107",
+                                                                "700": "#f09100",
+                                                                "900": "#d14900",
+                                                              },
+                                                              "text": Object {
+                                                                "0": "#ffffff",
+                                                                "100": "#f2f2f2",
+                                                                "1000": "#000000",
+                                                                "300": "#e0e0e0",
+                                                                "500": "#999999",
+                                                                "700": "#424242",
+                                                                "900": "#191919",
+                                                              },
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "spacing": Object {
+                                                        "large": 24,
+                                                        "medium": 16,
+                                                        "small": 12,
+                                                        "xlarge": 32,
+                                                        "xsmall": 8,
+                                                        "xxlarge": 40,
+                                                        "xxsmall": 4,
+                                                        "xxxlarge": 48,
+                                                        "xxxsmall": 2,
+                                                      },
+                                                    }
+                                                  }
+                                                >
+                                                  <svg
+                                                    aria-hidden="true"
+                                                    className="MuiSvgIcon-root c12 c13 c14"
+                                                    focusable="false"
+                                                    role="presentation"
+                                                    style={
+                                                      Object {
+                                                        "color": "",
+                                                        "fontSize": 24,
+                                                      }
+                                                    }
+                                                    theme={
+                                                      Object {
+                                                        "breakpoints": Object {
+                                                          "large": Object {
+                                                            "columns": 12,
+                                                            "width": 1440,
+                                                          },
+                                                          "medium": Object {
+                                                            "columns": 12,
+                                                            "width": 1024,
+                                                          },
+                                                          "small": Object {
+                                                            "columns": 8,
+                                                            "width": 600,
+                                                          },
+                                                          "xlarge": Object {
+                                                            "columns": 12,
+                                                            "width": 1920,
+                                                          },
+                                                          "xsmall": Object {
+                                                            "columns": 4,
+                                                          },
+                                                        },
+                                                        "colors": Object {
+                                                          "error": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "neutral": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "primary": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "secondary": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "success": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                        },
+                                                        "components": Object {
+                                                          "button": Object {
+                                                            "skins": Object {
+                                                              "error": Object {
+                                                                "mainColor": Object {
+                                                                  "100": "#fff5f5",
+                                                                  "300": "#f88e86",
+                                                                  "500": "#ec584e",
+                                                                  "700": "#e91b0c",
+                                                                  "900": "#ac001a",
+                                                                },
+                                                                "text": Object {
+                                                                  "0": "#ffffff",
+                                                                  "100": "#f2f2f2",
+                                                                  "1000": "#000000",
+                                                                  "300": "#e0e0e0",
+                                                                  "500": "#999999",
+                                                                  "700": "#424242",
+                                                                  "900": "#191919",
+                                                                },
+                                                              },
+                                                              "neutral": Object {
+                                                                "mainColor": Object {
+                                                                  "0": "#ffffff",
+                                                                  "100": "#f2f2f2",
+                                                                  "1000": "#000000",
+                                                                  "300": "#e0e0e0",
+                                                                  "500": "#999999",
+                                                                  "700": "#424242",
+                                                                  "900": "#191919",
+                                                                },
+                                                                "text": Object {
+                                                                  "0": "#ffffff",
+                                                                  "100": "#f2f2f2",
+                                                                  "1000": "#000000",
+                                                                  "300": "#e0e0e0",
+                                                                  "500": "#999999",
+                                                                  "700": "#424242",
+                                                                  "900": "#191919",
+                                                                },
+                                                              },
+                                                              "primary": Object {
+                                                                "mainColor": Object {
+                                                                  "100": "#E5EDFC",
+                                                                  "300": "#89AAE7",
+                                                                  "500": "#0CC0EA",
+                                                                  "700": "#1250C4",
+                                                                  "900": "#002F7B",
+                                                                },
+                                                                "text": Object {
+                                                                  "0": "#ffffff",
+                                                                  "100": "#f2f2f2",
+                                                                  "1000": "#000000",
+                                                                  "300": "#e0e0e0",
+                                                                  "500": "#999999",
+                                                                  "700": "#424242",
+                                                                  "900": "#191919",
+                                                                },
+                                                              },
+                                                              "secondary": Object {
+                                                                "mainColor": Object {
+                                                                  "100": "#F7B0C8",
+                                                                  "300": "#F278A1",
+                                                                  "500": "#E91E63",
+                                                                  "700": "#DE0059",
+                                                                  "900": "#9E003F",
+                                                                },
+                                                                "text": Object {
+                                                                  "0": "#ffffff",
+                                                                  "100": "#f2f2f2",
+                                                                  "1000": "#000000",
+                                                                  "300": "#e0e0e0",
+                                                                  "500": "#999999",
+                                                                  "700": "#424242",
+                                                                  "900": "#191919",
+                                                                },
+                                                              },
+                                                              "success": Object {
+                                                                "mainColor": Object {
+                                                                  "100": "#dcedc8",
+                                                                  "300": "#c9eda2",
+                                                                  "500": "#7ed321",
+                                                                  "700": "#3b610f",
+                                                                  "900": "#004D40",
+                                                                },
+                                                                "text": Object {
+                                                                  "0": "#ffffff",
+                                                                  "100": "#f2f2f2",
+                                                                  "1000": "#000000",
+                                                                  "300": "#e0e0e0",
+                                                                  "500": "#999999",
+                                                                  "700": "#424242",
+                                                                  "900": "#191919",
+                                                                },
+                                                              },
+                                                              "warning": Object {
+                                                                "mainColor": Object {
+                                                                  "100": "#ffefd6",
+                                                                  "300": "#ffda6a",
+                                                                  "500": "#ffc107",
+                                                                  "700": "#f09100",
+                                                                  "900": "#d14900",
+                                                                },
+                                                                "text": Object {
+                                                                  "0": "#ffffff",
+                                                                  "100": "#f2f2f2",
+                                                                  "1000": "#000000",
+                                                                  "300": "#e0e0e0",
+                                                                  "500": "#999999",
+                                                                  "700": "#424242",
+                                                                  "900": "#191919",
+                                                                },
+                                                              },
+                                                            },
+                                                          },
+                                                        },
+                                                        "spacing": Object {
+                                                          "large": 24,
+                                                          "medium": 16,
+                                                          "small": 12,
+                                                          "xlarge": 32,
+                                                          "xsmall": 8,
+                                                          "xxlarge": 40,
+                                                          "xxsmall": 4,
+                                                          "xxxlarge": 48,
+                                                          "xxxsmall": 2,
+                                                        },
+                                                      }
+                                                    }
+                                                    viewBox="0 0 24 24"
+                                                  >
+                                                    <path
+                                                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                    />
+                                                  </svg>
+                                                </ForwardRef(SvgIcon)>
+                                              </WithStyles(ForwardRef(SvgIcon))>
+                                            </ForwardRef>
+                                          </StyledComponent>
+                                        </Icon__SelectedIcon>
                                       </Icon>
                                     </StyledComponent>
                                   </Button__ButtonIcon>

--- a/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
+++ b/components/Modal/__snapshots__/Modal.unit.test.jsx.snap
@@ -185,7 +185,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
 }
 
 .c14 {
-  width: 24px;
+  width: 0px;
 }
 
 @media (min-width:0px) {
@@ -600,7 +600,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
 }
 
 .c14 {
-  width: 24px;
+  width: 0px;
 }
 
 @media (min-width:0px) {
@@ -4879,7 +4879,7 @@ exports[`<Modal /> Snapshots should match the snapshot 1`] = `
                                                   "isStatic": true,
                                                   "lastClassName": "c14",
                                                   "rules": Array [
-                                                    "width:24px;",
+                                                    "width:0px;",
                                                   ],
                                                 },
                                                 "displayName": "Icon__SelectedIcon",

--- a/components/Popover/__snapshots__/Popover.unit.test.jsx.snap
+++ b/components/Popover/__snapshots__/Popover.unit.test.jsx.snap
@@ -1104,7 +1104,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -1545,7 +1545,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -4450,7 +4450,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",
@@ -5864,7 +5864,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -6305,7 +6305,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -9210,7 +9210,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",
@@ -10640,7 +10640,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -11097,7 +11097,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -14002,7 +14002,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",
@@ -15448,7 +15448,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -15921,7 +15921,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -18826,7 +18826,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",
@@ -20288,7 +20288,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -20777,7 +20777,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -23682,7 +23682,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",
@@ -25144,7 +25144,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -25633,7 +25633,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -28538,7 +28538,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",
@@ -29997,7 +29997,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -30483,7 +30483,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -33388,7 +33388,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",
@@ -34847,7 +34847,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 {
-  width: 24px;
+  width: 0px;
 }
 
 <Popover
@@ -35333,7 +35333,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <section>
@@ -38238,7 +38238,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                               "isStatic": true,
                                               "lastClassName": "c6",
                                               "rules": Array [
-                                                "width:24px;",
+                                                "width:0px;",
                                               ],
                                             },
                                             "displayName": "Icon__SelectedIcon",

--- a/components/Popover/__snapshots__/Popover.unit.test.jsx.snap
+++ b/components/Popover/__snapshots__/Popover.unit.test.jsx.snap
@@ -1099,8 +1099,12 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -1540,6 +1544,10 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <section>
                 <div
                   class="c0"
@@ -1556,7 +1564,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -4199,7 +4207,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -4430,8 +4438,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -4661,21 +4703,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -4905,11 +4934,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -5138,15 +5164,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -5172,7 +5678,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -5191,7 +5697,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>
@@ -5353,8 +5859,12 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -5794,6 +6304,10 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <section>
                 <div
                   class="c0"
@@ -5810,7 +6324,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -8453,7 +8967,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -8684,8 +9198,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -8915,21 +9463,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -9159,11 +9694,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -9392,15 +9924,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -9426,7 +10438,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -9445,7 +10457,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>
@@ -9467,7 +10479,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   width: 24px;
 }
 
-.c7 .c4 function (_ref6) {
+.c8 .c4 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -9475,7 +10487,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c7 .c4 function (_ref6) var fontSizes = {
+.c8 .c4 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -9571,7 +10583,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   transform: translateX(-50%);
 }
 
-.c8 .c4 {
+.c9 .c4 {
   margin-right: 0;
 }
 
@@ -9623,8 +10635,12 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -9929,7 +10945,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   width: 24px;
 }
 
-.c5 .c3 function (_ref6) {
+.c6 .c3 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -9937,7 +10953,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c5 .c3 function (_ref6) var fontSizes = {
+.c6 .c3 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -10033,7 +11049,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   transform: translateX(-50%);
 }
 
-.c6 .c3 {
+.c7 .c3 {
   margin-right: 0;
 }
 
@@ -10080,6 +11096,10 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #004D40;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <section>
                 <div
                   class="c0"
@@ -10096,7 +11116,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -12739,7 +13759,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -12970,8 +13990,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -13201,21 +14255,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -13445,11 +14486,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -13678,15 +14716,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -13712,7 +15230,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -13731,7 +15249,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>
@@ -13753,18 +15271,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   width: 24px;
 }
 
-.c7 .c4 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c7 .c4 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c8 .c4 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -13774,6 +15280,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c8 .c4 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c9 .c4 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c9 .c4 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -13869,11 +15387,11 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   transform: translateX(-50%);
 }
 
-.c9 .c4 {
+.c10 .c4 {
   margin-right: 0;
 }
 
-.c10 .c4 {
+.c11 .c4 {
   margin-right: 0;
 }
 
@@ -13925,8 +15443,12 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -14231,18 +15753,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   width: 24px;
 }
 
-.c5 .c3 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c5 .c3 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c6 .c3 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -14252,6 +15762,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c6 .c3 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c7 .c3 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c7 .c3 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -14347,11 +15869,11 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   transform: translateX(-50%);
 }
 
-.c7 .c3 {
+.c8 .c3 {
   margin-right: 0;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   margin-right: 0;
 }
 
@@ -14398,6 +15920,10 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <section>
                 <div
                   class="c0"
@@ -14414,7 +15940,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -17057,7 +18583,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -17288,8 +18814,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -17519,21 +19079,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -17763,11 +19310,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -17996,15 +19540,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -18030,7 +20054,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -18049,7 +20073,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>
@@ -18069,18 +20093,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   margin-right: 8px;
   pointer-events: none;
   width: 24px;
-}
-
-.c7 .c4 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c7 .c4 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
 .c8 .c4 function (_ref6) {
@@ -18104,6 +20116,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c9 .c4 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c10 .c4 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c10 .c4 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -18199,15 +20223,15 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   transform: translateX(-50%);
 }
 
-.c10 .c4 {
-  margin-right: 0;
-}
-
 .c11 .c4 {
   margin-right: 0;
 }
 
 .c12 .c4 {
+  margin-right: 0;
+}
+
+.c13 .c4 {
   margin-right: 0;
 }
 
@@ -18259,8 +20283,12 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -18565,18 +20593,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   width: 24px;
 }
 
-.c5 .c3 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c5 .c3 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c6 .c3 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -18598,6 +20614,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c7 .c3 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c8 .c3 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c8 .c3 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -18693,15 +20721,15 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   transform: translateX(-50%);
 }
 
-.c8 .c3 {
-  margin-right: 0;
-}
-
 .c9 .c3 {
   margin-right: 0;
 }
 
 .c10 .c3 {
+  margin-right: 0;
+}
+
+.c11 .c3 {
   margin-right: 0;
 }
 
@@ -18748,6 +20776,10 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <section>
                 <div
                   class="c0"
@@ -18764,7 +20796,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -21407,7 +23439,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -21638,8 +23670,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -21869,21 +23935,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -22113,11 +24166,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -22346,15 +24396,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -22380,7 +24910,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -22399,7 +24929,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>
@@ -22478,18 +25008,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c7 .c4 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c7 .c4 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c8 .c4 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -22511,6 +25029,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c9 .c4 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c10 .c4 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c10 .c4 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -22592,10 +25122,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
-.c10 .c4 {
-  margin-right: 0;
-}
-
 .c11 .c4 {
   margin-right: 0;
 }
@@ -22604,13 +25130,21 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   margin-right: 0;
 }
 
+.c13 .c4 {
+  margin-right: 0;
+}
+
 .c0 {
   display: inline-block;
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -22972,18 +25506,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c5 .c3 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c5 .c3 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c6 .c3 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -23005,6 +25527,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c7 .c3 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c8 .c3 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c8 .c3 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -23086,16 +25620,20 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
-.c8 .c3 {
-  margin-right: 0;
-}
-
 .c9 .c3 {
   margin-right: 0;
 }
 
 .c10 .c3 {
   margin-right: 0;
+}
+
+.c11 .c3 {
+  margin-right: 0;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <section>
@@ -23114,7 +25652,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -25757,7 +28295,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -25988,8 +28526,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -26219,21 +28791,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -26463,11 +29022,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -26696,15 +29252,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -26730,7 +29766,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -26749,7 +29785,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>
@@ -26828,18 +29864,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c7 .c4 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c7 .c4 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c8 .c4 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -26861,6 +29885,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c9 .c4 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c10 .c4 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c10 .c4 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -26939,10 +29975,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
-.c10 .c4 {
-  margin-right: 0;
-}
-
 .c11 .c4 {
   margin-right: 0;
 }
@@ -26951,13 +29983,21 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   margin-right: 0;
 }
 
+.c13 .c4 {
+  margin-right: 0;
+}
+
 .c0 {
   display: inline-block;
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -27319,18 +30359,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c5 .c3 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c5 .c3 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c6 .c3 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -27352,6 +30380,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c7 .c3 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c8 .c3 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c8 .c3 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -27430,16 +30470,20 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
-.c8 .c3 {
-  margin-right: 0;
-}
-
 .c9 .c3 {
   margin-right: 0;
 }
 
 .c10 .c3 {
   margin-right: 0;
+}
+
+.c11 .c3 {
+  margin-right: 0;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <section>
@@ -27458,7 +30502,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -30101,7 +33145,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -30332,8 +33376,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -30563,21 +33641,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -30807,11 +33872,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -31040,15 +34102,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -31074,7 +34616,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -31093,7 +34635,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>
@@ -31172,18 +34714,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c7 .c4 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c7 .c4 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c8 .c4 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -31205,6 +34735,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c9 .c4 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c10 .c4 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c10 .c4 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -31283,10 +34825,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
-.c10 .c4 {
-  margin-right: 0;
-}
-
 .c11 .c4 {
   margin-right: 0;
 }
@@ -31295,13 +34833,21 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   margin-right: 0;
 }
 
+.c13 .c4 {
+  margin-right: 0;
+}
+
 .c0 {
   display: inline-block;
   position: relative;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
+}
+
+.c6 {
+  width: 24px;
 }
 
 <Popover
@@ -31663,18 +35209,6 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
-.c5 .c3 function (_ref6) {
-  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
-  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
-}
-
-.c5 .c3 function (_ref6) var fontSizes = {
-  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
-}
-
 .c6 .c3 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -31696,6 +35230,18 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
 }
 
 .c7 .c3 function (_ref6) var fontSizes = {
+  xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
+}
+
+.c8 .c3 function (_ref6) {
+  -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
+  return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
+}
+
+.c8 .c3 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -31774,16 +35320,20 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
   color: #424242;
 }
 
-.c8 .c3 {
-  margin-right: 0;
-}
-
 .c9 .c3 {
   margin-right: 0;
 }
 
 .c10 .c3 {
   margin-right: 0;
+}
+
+.c11 .c3 {
+  margin-right: 0;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <section>
@@ -31802,7 +35352,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root c3 c4"
+                      class="MuiSvgIcon-root c3 c4 c5"
                       focusable="false"
                       role="presentation"
                       style="font-size: 24px;"
@@ -34445,7 +37995,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                       }
                                     }
                                   >
-                                    <ForwardRef
+                                    <Icon__SelectedIcon
                                       className="c4 c5"
                                       style={
                                         Object {
@@ -34676,8 +38226,42 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                         }
                                       }
                                     >
-                                      <WithStyles(ForwardRef(SvgIcon))
+                                      <StyledComponent
                                         className="c4 c5"
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "compare": null,
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                              "isStatic": true,
+                                              "lastClassName": "c6",
+                                              "rules": Array [
+                                                "width:24px;",
+                                              ],
+                                            },
+                                            "displayName": "Icon__SelectedIcon",
+                                            "foldedComponentIds": Array [],
+                                            "muiName": "SvgIcon",
+                                            "render": [Function],
+                                            "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                                            "target": Object {
+                                              "$$typeof": Symbol(react.memo),
+                                              "compare": null,
+                                              "displayName": "CloseIcon",
+                                              "muiName": "SvgIcon",
+                                              "type": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
                                         style={
                                           Object {
                                             "color": "",
@@ -34907,21 +38491,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                           }
                                         }
                                       >
-                                        <ForwardRef(SvgIcon)
-                                          className="c4 c5"
-                                          classes={
-                                            Object {
-                                              "colorAction": "MuiSvgIcon-colorAction",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                              "colorError": "MuiSvgIcon-colorError",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                              "root": "MuiSvgIcon-root",
-                                            }
-                                          }
+                                        <ForwardRef
+                                          className="c4 c5 c6"
                                           style={
                                             Object {
                                               "color": "",
@@ -35151,11 +38722,8 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                             }
                                           }
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            className="MuiSvgIcon-root c4 c5"
-                                            focusable="false"
-                                            role="presentation"
+                                          <WithStyles(ForwardRef(SvgIcon))
+                                            className="c4 c5 c6"
                                             style={
                                               Object {
                                                 "color": "",
@@ -35384,15 +38952,495 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                                                 },
                                               }
                                             }
-                                            viewBox="0 0 24 24"
                                           >
-                                            <path
-                                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                            />
-                                          </svg>
-                                        </ForwardRef(SvgIcon)>
-                                      </WithStyles(ForwardRef(SvgIcon))>
-                                    </ForwardRef>
+                                            <ForwardRef(SvgIcon)
+                                              className="c4 c5 c6"
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                              style={
+                                                Object {
+                                                  "color": "",
+                                                  "fontSize": 24,
+                                                }
+                                              }
+                                              theme={
+                                                Object {
+                                                  "breakpoints": Object {
+                                                    "large": Object {
+                                                      "columns": 12,
+                                                      "width": 1440,
+                                                    },
+                                                    "medium": Object {
+                                                      "columns": 12,
+                                                      "width": 1024,
+                                                    },
+                                                    "small": Object {
+                                                      "columns": 8,
+                                                      "width": 600,
+                                                    },
+                                                    "xlarge": Object {
+                                                      "columns": 12,
+                                                      "width": 1920,
+                                                    },
+                                                    "xsmall": Object {
+                                                      "columns": 4,
+                                                    },
+                                                  },
+                                                  "colors": Object {
+                                                    "error": Object {
+                                                      "100": "#fff5f5",
+                                                      "300": "#f88e86",
+                                                      "500": "#ec584e",
+                                                      "700": "#e91b0c",
+                                                      "900": "#ac001a",
+                                                    },
+                                                    "neutral": Object {
+                                                      "0": "#ffffff",
+                                                      "100": "#f2f2f2",
+                                                      "1000": "#000000",
+                                                      "300": "#e0e0e0",
+                                                      "500": "#999999",
+                                                      "700": "#424242",
+                                                      "900": "#191919",
+                                                    },
+                                                    "primary": Object {
+                                                      "100": "#E5EDFC",
+                                                      "300": "#89AAE7",
+                                                      "500": "#0CC0EA",
+                                                      "700": "#1250C4",
+                                                      "900": "#002F7B",
+                                                    },
+                                                    "secondary": Object {
+                                                      "100": "#F7B0C8",
+                                                      "300": "#F278A1",
+                                                      "500": "#E91E63",
+                                                      "700": "#DE0059",
+                                                      "900": "#9E003F",
+                                                    },
+                                                    "success": Object {
+                                                      "100": "#dcedc8",
+                                                      "300": "#c9eda2",
+                                                      "500": "#7ed321",
+                                                      "700": "#3b610f",
+                                                      "900": "#004D40",
+                                                    },
+                                                    "warning": Object {
+                                                      "100": "#ffefd6",
+                                                      "300": "#ffda6a",
+                                                      "500": "#ffc107",
+                                                      "700": "#f09100",
+                                                      "900": "#d14900",
+                                                    },
+                                                  },
+                                                  "components": Object {
+                                                    "button": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#fff5f5",
+                                                            "300": "#f88e86",
+                                                            "500": "#ec584e",
+                                                            "700": "#e91b0c",
+                                                            "900": "#ac001a",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "neutral": Object {
+                                                          "mainColor": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "primary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#E5EDFC",
+                                                            "300": "#89AAE7",
+                                                            "500": "#0CC0EA",
+                                                            "700": "#1250C4",
+                                                            "900": "#002F7B",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "secondary": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#F7B0C8",
+                                                            "300": "#F278A1",
+                                                            "500": "#E91E63",
+                                                            "700": "#DE0059",
+                                                            "900": "#9E003F",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "success": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#dcedc8",
+                                                            "300": "#c9eda2",
+                                                            "500": "#7ed321",
+                                                            "700": "#3b610f",
+                                                            "900": "#004D40",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                        "warning": Object {
+                                                          "mainColor": Object {
+                                                            "100": "#ffefd6",
+                                                            "300": "#ffda6a",
+                                                            "500": "#ffc107",
+                                                            "700": "#f09100",
+                                                            "900": "#d14900",
+                                                          },
+                                                          "text": Object {
+                                                            "0": "#ffffff",
+                                                            "100": "#f2f2f2",
+                                                            "1000": "#000000",
+                                                            "300": "#e0e0e0",
+                                                            "500": "#999999",
+                                                            "700": "#424242",
+                                                            "900": "#191919",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "popover": Object {
+                                                      "skins": Object {
+                                                        "error": Object {
+                                                          "background": "#fff5f5",
+                                                          "text": "#424242",
+                                                        },
+                                                        "neutral": Object {
+                                                          "background": "#ffffff",
+                                                          "text": "#424242",
+                                                        },
+                                                        "primary": Object {
+                                                          "background": "#E5EDFC",
+                                                          "text": "#424242",
+                                                        },
+                                                        "success": Object {
+                                                          "background": "#dcedc8",
+                                                          "text": "#004D40",
+                                                        },
+                                                        "warning": Object {
+                                                          "background": "#ffefd6",
+                                                          "text": "#424242",
+                                                        },
+                                                      },
+                                                    },
+                                                  },
+                                                  "spacing": Object {
+                                                    "large": 24,
+                                                    "medium": 16,
+                                                    "small": 12,
+                                                    "xlarge": 32,
+                                                    "xsmall": 8,
+                                                    "xxlarge": 40,
+                                                    "xxsmall": 4,
+                                                    "xxxlarge": 48,
+                                                    "xxxsmall": 2,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root c4 c5 c6"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "",
+                                                    "fontSize": 24,
+                                                  }
+                                                }
+                                                theme={
+                                                  Object {
+                                                    "breakpoints": Object {
+                                                      "large": Object {
+                                                        "columns": 12,
+                                                        "width": 1440,
+                                                      },
+                                                      "medium": Object {
+                                                        "columns": 12,
+                                                        "width": 1024,
+                                                      },
+                                                      "small": Object {
+                                                        "columns": 8,
+                                                        "width": 600,
+                                                      },
+                                                      "xlarge": Object {
+                                                        "columns": 12,
+                                                        "width": 1920,
+                                                      },
+                                                      "xsmall": Object {
+                                                        "columns": 4,
+                                                      },
+                                                    },
+                                                    "colors": Object {
+                                                      "error": Object {
+                                                        "100": "#fff5f5",
+                                                        "300": "#f88e86",
+                                                        "500": "#ec584e",
+                                                        "700": "#e91b0c",
+                                                        "900": "#ac001a",
+                                                      },
+                                                      "neutral": Object {
+                                                        "0": "#ffffff",
+                                                        "100": "#f2f2f2",
+                                                        "1000": "#000000",
+                                                        "300": "#e0e0e0",
+                                                        "500": "#999999",
+                                                        "700": "#424242",
+                                                        "900": "#191919",
+                                                      },
+                                                      "primary": Object {
+                                                        "100": "#E5EDFC",
+                                                        "300": "#89AAE7",
+                                                        "500": "#0CC0EA",
+                                                        "700": "#1250C4",
+                                                        "900": "#002F7B",
+                                                      },
+                                                      "secondary": Object {
+                                                        "100": "#F7B0C8",
+                                                        "300": "#F278A1",
+                                                        "500": "#E91E63",
+                                                        "700": "#DE0059",
+                                                        "900": "#9E003F",
+                                                      },
+                                                      "success": Object {
+                                                        "100": "#dcedc8",
+                                                        "300": "#c9eda2",
+                                                        "500": "#7ed321",
+                                                        "700": "#3b610f",
+                                                        "900": "#004D40",
+                                                      },
+                                                      "warning": Object {
+                                                        "100": "#ffefd6",
+                                                        "300": "#ffda6a",
+                                                        "500": "#ffc107",
+                                                        "700": "#f09100",
+                                                        "900": "#d14900",
+                                                      },
+                                                    },
+                                                    "components": Object {
+                                                      "button": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#fff5f5",
+                                                              "300": "#f88e86",
+                                                              "500": "#ec584e",
+                                                              "700": "#e91b0c",
+                                                              "900": "#ac001a",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "neutral": Object {
+                                                            "mainColor": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "primary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#E5EDFC",
+                                                              "300": "#89AAE7",
+                                                              "500": "#0CC0EA",
+                                                              "700": "#1250C4",
+                                                              "900": "#002F7B",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "secondary": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#F7B0C8",
+                                                              "300": "#F278A1",
+                                                              "500": "#E91E63",
+                                                              "700": "#DE0059",
+                                                              "900": "#9E003F",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "success": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#dcedc8",
+                                                              "300": "#c9eda2",
+                                                              "500": "#7ed321",
+                                                              "700": "#3b610f",
+                                                              "900": "#004D40",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                          "warning": Object {
+                                                            "mainColor": Object {
+                                                              "100": "#ffefd6",
+                                                              "300": "#ffda6a",
+                                                              "500": "#ffc107",
+                                                              "700": "#f09100",
+                                                              "900": "#d14900",
+                                                            },
+                                                            "text": Object {
+                                                              "0": "#ffffff",
+                                                              "100": "#f2f2f2",
+                                                              "1000": "#000000",
+                                                              "300": "#e0e0e0",
+                                                              "500": "#999999",
+                                                              "700": "#424242",
+                                                              "900": "#191919",
+                                                            },
+                                                          },
+                                                        },
+                                                      },
+                                                      "popover": Object {
+                                                        "skins": Object {
+                                                          "error": Object {
+                                                            "background": "#fff5f5",
+                                                            "text": "#424242",
+                                                          },
+                                                          "neutral": Object {
+                                                            "background": "#ffffff",
+                                                            "text": "#424242",
+                                                          },
+                                                          "primary": Object {
+                                                            "background": "#E5EDFC",
+                                                            "text": "#424242",
+                                                          },
+                                                          "success": Object {
+                                                            "background": "#dcedc8",
+                                                            "text": "#004D40",
+                                                          },
+                                                          "warning": Object {
+                                                            "background": "#ffefd6",
+                                                            "text": "#424242",
+                                                          },
+                                                        },
+                                                      },
+                                                    },
+                                                    "spacing": Object {
+                                                      "large": 24,
+                                                      "medium": 16,
+                                                      "small": 12,
+                                                      "xlarge": 32,
+                                                      "xsmall": 8,
+                                                      "xxlarge": 40,
+                                                      "xxsmall": 4,
+                                                      "xxxlarge": 48,
+                                                      "xxxsmall": 2,
+                                                    },
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </StyledComponent>
+                                    </Icon__SelectedIcon>
                                   </Icon>
                                 </StyledComponent>
                               </Button__ButtonIcon>
@@ -35418,7 +39466,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
                 "componentStyle": ComponentStyle {
                   "componentId": "Popover__TriggerBlock-sc-94rrmp-1",
                   "isStatic": true,
-                  "lastClassName": "c6",
+                  "lastClassName": "c7",
                   "rules": Array [
                     "cursor:pointer;",
                   ],
@@ -35437,7 +39485,7 @@ exports[`Popover component  Snapshots should match the snapshots after click on 
             onClick={[Function]}
           >
             <div
-              className="c6"
+              className="c7"
               onClick={[Function]}
             >
               <span>

--- a/components/RadioGroup/__snapshots__/RadioButton.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/RadioButton.unit.test.jsx.snap
@@ -279,7 +279,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -575,7 +575,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled with an error 1`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -986,7 +986,7 @@ exports[`<RadioGroup.Radio /> snapshot icon 1`] = `
 }
 
 .c4 {
-  width: 24px;
+  width: 0px;
 }
 
 <div

--- a/components/RadioGroup/__snapshots__/RadioButton.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/RadioButton.unit.test.jsx.snap
@@ -249,7 +249,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
   box-shadow: 0px 3px 1px -2px rgba(153,153,153,0.2),0px 2px 2px 0px rgba(153,153,153,0.14),0px 1px 5px 0px rgba(153,153,153,0.12);
 }
 
-.c1 .c6 function (_ref6) {
+.c1 .c7 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -257,7 +257,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c1 .c6 function (_ref6) var fontSizes = {
+.c1 .c7 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -265,7 +265,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
   margin-left: 8px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 16px;
   margin-left: 8px;
 }
@@ -276,6 +276,10 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -303,7 +307,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
     Foo
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c3 c4"
+      className="MuiSvgIcon-root c3 c4 c5"
       focusable="false"
       role="presentation"
       style={
@@ -541,7 +545,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled with an error 1`] = `
   box-shadow: 0px 3px 1px -2px rgba(153,153,153,0.2),0px 2px 2px 0px rgba(153,153,153,0.14),0px 1px 5px 0px rgba(153,153,153,0.12);
 }
 
-.c1 .c6 function (_ref6) {
+.c1 .c7 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -549,7 +553,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled with an error 1`] = `
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c1 .c6 function (_ref6) var fontSizes = {
+.c1 .c7 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -557,7 +561,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled with an error 1`] = `
   margin-left: 8px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 16px;
   margin-left: 8px;
 }
@@ -568,6 +572,10 @@ exports[`<RadioGroup.Radio /> snapshot disabled with an error 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -595,7 +603,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled with an error 1`] = `
     Foo
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c3 c4"
+      className="MuiSvgIcon-root c3 c4 c5"
       focusable="false"
       role="presentation"
       style={
@@ -953,7 +961,7 @@ exports[`<RadioGroup.Radio /> snapshot icon 1`] = `
   background-color: #E5EDFC;
 }
 
-.c1 .c4 function (_ref6) {
+.c1 .c5 function (_ref6) {
   -webkit-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -moz-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
   -ms-var: size = _ref6.size, _ref6$theme$spacing = _ref6.theme.spacing, xxsmall = _ref6$theme$spacing.xxsmall, medium = _ref6$theme$spacing.medium, large = _ref6$theme$spacing.large;
@@ -961,7 +969,7 @@ exports[`<RadioGroup.Radio /> snapshot icon 1`] = `
   return: "\\n          font-size: ".concat(fontSizes[size],";\\n          margin-right: ").concat(xxsmall,"px;\\n        ");
 }
 
-.c1 .c4 function (_ref6) var fontSizes = {
+.c1 .c5 function (_ref6) var fontSizes = {
   xsmall: "".concat(medium,"px"), small:"".concat(medium,"px"), medium:"".concat(large,"px"), large:"".concat(large,"px"), xlarge:"".concat(large,"px");
 }
 
@@ -975,6 +983,10 @@ exports[`<RadioGroup.Radio /> snapshot icon 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c4 {
+  width: 24px;
 }
 
 <div
@@ -1001,7 +1013,7 @@ exports[`<RadioGroup.Radio /> snapshot icon 1`] = `
     />
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c3"
+      className="MuiSvgIcon-root c3 c4"
       focusable="false"
       role="presentation"
       style={

--- a/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
+++ b/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
@@ -2078,7 +2078,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
 }
 
 .c7 {
-  width: 24px;
+  width: 0px;
 }
 
 @media (min-width:1024px) {
@@ -4916,7 +4916,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                                 "isStatic": true,
                                 "lastClassName": "c7",
                                 "rules": Array [
-                                  "width:24px;",
+                                  "width:0px;",
                                 ],
                               },
                               "displayName": "Icon__SelectedIcon",
@@ -5824,7 +5824,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                                 "isStatic": true,
                                 "lastClassName": "c7",
                                 "rules": Array [
-                                  "width:24px;",
+                                  "width:0px;",
                                 ],
                               },
                               "displayName": "Icon__SelectedIcon",

--- a/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
+++ b/components/TabbedView/__snapshots__/TabbedView.unit.test.jsx.snap
@@ -2041,7 +2041,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
   width: 24px;
 }
 
-.c7 {
+.c8 {
   clear: left;
 }
 
@@ -2075,6 +2075,10 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
   padding-right: 2px;
   background-color: #f2f2f2;
   color: #424242;
+}
+
+.c7 {
+  width: 24px;
 }
 
 @media (min-width:1024px) {
@@ -4893,7 +4897,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                       skin=""
                       style={Object {}}
                     >
-                      <ForwardRef
+                      <Icon__SelectedIcon
                         style={
                           Object {
                             "color": "",
@@ -4901,7 +4905,41 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                           }
                         }
                       >
-                        <WithStyles(ForwardRef(SvgIcon))
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "compare": null,
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                "isStatic": true,
+                                "lastClassName": "c7",
+                                "rules": Array [
+                                  "width:24px;",
+                                ],
+                              },
+                              "displayName": "Icon__SelectedIcon",
+                              "foldedComponentIds": Array [],
+                              "muiName": "SvgIcon",
+                              "render": [Function],
+                              "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                              "target": Object {
+                                "$$typeof": Symbol(react.memo),
+                                "compare": null,
+                                "displayName": "StarIcon",
+                                "muiName": "SvgIcon",
+                                "type": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                },
+                              },
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
                           style={
                             Object {
                               "color": "",
@@ -4909,20 +4947,8 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                             }
                           }
                         >
-                          <ForwardRef(SvgIcon)
-                            classes={
-                              Object {
-                                "colorAction": "MuiSvgIcon-colorAction",
-                                "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                "colorError": "MuiSvgIcon-colorError",
-                                "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                "root": "MuiSvgIcon-root",
-                              }
-                            }
+                          <ForwardRef
+                            className="c7"
                             style={
                               Object {
                                 "color": "",
@@ -4930,26 +4956,59 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                               }
                             }
                           >
-                            <svg
-                              aria-hidden="true"
-                              className="MuiSvgIcon-root"
-                              focusable="false"
-                              role="presentation"
+                            <WithStyles(ForwardRef(SvgIcon))
+                              className="c7"
                               style={
                                 Object {
                                   "color": "",
                                   "fontSize": 24,
                                 }
                               }
-                              viewBox="0 0 24 24"
                             >
-                              <path
-                                d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-                              />
-                            </svg>
-                          </ForwardRef(SvgIcon)>
-                        </WithStyles(ForwardRef(SvgIcon))>
-                      </ForwardRef>
+                              <ForwardRef(SvgIcon)
+                                className="c7"
+                                classes={
+                                  Object {
+                                    "colorAction": "MuiSvgIcon-colorAction",
+                                    "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                    "colorError": "MuiSvgIcon-colorError",
+                                    "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                    "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                    "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                    "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                    "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                    "root": "MuiSvgIcon-root",
+                                  }
+                                }
+                                style={
+                                  Object {
+                                    "color": "",
+                                    "fontSize": 24,
+                                  }
+                                }
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="MuiSvgIcon-root c7"
+                                  focusable="false"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "color": "",
+                                      "fontSize": 24,
+                                    }
+                                  }
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+                                  />
+                                </svg>
+                              </ForwardRef(SvgIcon)>
+                            </WithStyles(ForwardRef(SvgIcon))>
+                          </ForwardRef>
+                        </StyledComponent>
+                      </Icon__SelectedIcon>
                     </Icon>
                   </div>
                 </StyledComponent>
@@ -5746,7 +5805,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                       skin=""
                       style={Object {}}
                     >
-                      <ForwardRef
+                      <Icon__SelectedIcon
                         style={
                           Object {
                             "color": "",
@@ -5754,7 +5813,41 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                           }
                         }
                       >
-                        <WithStyles(ForwardRef(SvgIcon))
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "compare": null,
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Icon__SelectedIcon-mfzsxw-0",
+                                "isStatic": true,
+                                "lastClassName": "c7",
+                                "rules": Array [
+                                  "width:24px;",
+                                ],
+                              },
+                              "displayName": "Icon__SelectedIcon",
+                              "foldedComponentIds": Array [],
+                              "muiName": "SvgIcon",
+                              "render": [Function],
+                              "styledComponentId": "Icon__SelectedIcon-mfzsxw-0",
+                              "target": Object {
+                                "$$typeof": Symbol(react.memo),
+                                "compare": null,
+                                "displayName": "StarIcon",
+                                "muiName": "SvgIcon",
+                                "type": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                },
+                              },
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
                           style={
                             Object {
                               "color": "",
@@ -5762,20 +5855,8 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                             }
                           }
                         >
-                          <ForwardRef(SvgIcon)
-                            classes={
-                              Object {
-                                "colorAction": "MuiSvgIcon-colorAction",
-                                "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                "colorError": "MuiSvgIcon-colorError",
-                                "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                "root": "MuiSvgIcon-root",
-                              }
-                            }
+                          <ForwardRef
+                            className="c7"
                             style={
                               Object {
                                 "color": "",
@@ -5783,26 +5864,59 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
                               }
                             }
                           >
-                            <svg
-                              aria-hidden="true"
-                              className="MuiSvgIcon-root"
-                              focusable="false"
-                              role="presentation"
+                            <WithStyles(ForwardRef(SvgIcon))
+                              className="c7"
                               style={
                                 Object {
                                   "color": "",
                                   "fontSize": 24,
                                 }
                               }
-                              viewBox="0 0 24 24"
                             >
-                              <path
-                                d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-                              />
-                            </svg>
-                          </ForwardRef(SvgIcon)>
-                        </WithStyles(ForwardRef(SvgIcon))>
-                      </ForwardRef>
+                              <ForwardRef(SvgIcon)
+                                className="c7"
+                                classes={
+                                  Object {
+                                    "colorAction": "MuiSvgIcon-colorAction",
+                                    "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                    "colorError": "MuiSvgIcon-colorError",
+                                    "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                    "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                    "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                    "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                    "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                    "root": "MuiSvgIcon-root",
+                                  }
+                                }
+                                style={
+                                  Object {
+                                    "color": "",
+                                    "fontSize": 24,
+                                  }
+                                }
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="MuiSvgIcon-root c7"
+                                  focusable="false"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "color": "",
+                                      "fontSize": 24,
+                                    }
+                                  }
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+                                  />
+                                </svg>
+                              </ForwardRef(SvgIcon)>
+                            </WithStyles(ForwardRef(SvgIcon))>
+                          </ForwardRef>
+                        </StyledComponent>
+                      </Icon__SelectedIcon>
                     </Icon>
                   </div>
                 </StyledComponent>
@@ -6873,7 +6987,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
             "componentStyle": ComponentStyle {
               "componentId": "TabbedView__TabPanel-sc-131sgnr-5",
               "isStatic": true,
-              "lastClassName": "c7",
+              "lastClassName": "c8",
               "rules": Array [
                 "clear:left;",
               ],
@@ -6894,7 +7008,7 @@ exports[`<TabbedView />  Snapshot should match snapshot with badges and icons 1`
       >
         <div
           aria-labelledby="with-badge-tab"
-          className="c7"
+          className="c8"
           id="with-badge-panel"
           role="tabpanel"
         >

--- a/components/Tag/__snapshots__/Tag.unit.test.jsx.snap
+++ b/components/Tag/__snapshots__/Tag.unit.test.jsx.snap
@@ -453,6 +453,10 @@ exports[`<Tag /> onClose Prop is rendering well 1`] = `
   color: #424242;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -469,7 +473,7 @@ exports[`<Tag /> onClose Prop is rendering well 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -516,7 +520,7 @@ exports[`<Tag /> onClose Prop is rendering well 2`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
@@ -535,6 +539,10 @@ exports[`<Tag /> onClose Prop is rendering well 2`] = `
   color: #1250C4;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -551,7 +559,7 @@ exports[`<Tag /> onClose Prop is rendering well 2`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -598,12 +606,12 @@ exports[`<Tag /> onClose Prop is rendering well 3`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
@@ -622,6 +630,10 @@ exports[`<Tag /> onClose Prop is rendering well 3`] = `
   color: #004D40;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -638,7 +650,7 @@ exports[`<Tag /> onClose Prop is rendering well 3`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -685,17 +697,17 @@ exports[`<Tag /> onClose Prop is rendering well 4`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
@@ -714,6 +726,10 @@ exports[`<Tag /> onClose Prop is rendering well 4`] = `
   color: #d14900;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -730,7 +746,7 @@ exports[`<Tag /> onClose Prop is rendering well 4`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -777,22 +793,22 @@ exports[`<Tag /> onClose Prop is rendering well 5`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
@@ -811,6 +827,10 @@ exports[`<Tag /> onClose Prop is rendering well 5`] = `
   color: #ac001a;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -827,7 +847,7 @@ exports[`<Tag /> onClose Prop is rendering well 5`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -874,27 +894,27 @@ exports[`<Tag /> onClose Prop is rendering well 6`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
@@ -913,6 +933,10 @@ exports[`<Tag /> onClose Prop is rendering well 6`] = `
   color: #f2f2f2;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -929,7 +953,7 @@ exports[`<Tag /> onClose Prop is rendering well 6`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -976,32 +1000,32 @@ exports[`<Tag /> onClose Prop is rendering well 7`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
@@ -1020,6 +1044,10 @@ exports[`<Tag /> onClose Prop is rendering well 7`] = `
   color: #E5EDFC;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -1036,7 +1064,7 @@ exports[`<Tag /> onClose Prop is rendering well 7`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1083,37 +1111,37 @@ exports[`<Tag /> onClose Prop is rendering well 8`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
@@ -1132,6 +1160,10 @@ exports[`<Tag /> onClose Prop is rendering well 8`] = `
   color: #dcedc8;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -1148,7 +1180,7 @@ exports[`<Tag /> onClose Prop is rendering well 8`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1195,42 +1227,42 @@ exports[`<Tag /> onClose Prop is rendering well 9`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
 
-.c12 .c3 {
+.c13 .c3 {
   font-size: 18px !important;
   color: #dcedc8;
 }
@@ -1249,6 +1281,10 @@ exports[`<Tag /> onClose Prop is rendering well 9`] = `
   color: #ffefd6;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -1265,7 +1301,7 @@ exports[`<Tag /> onClose Prop is rendering well 9`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1312,47 +1348,47 @@ exports[`<Tag /> onClose Prop is rendering well 10`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
 
-.c12 .c3 {
+.c13 .c3 {
   font-size: 18px !important;
   color: #dcedc8;
 }
 
-.c13 .c3 {
+.c14 .c3 {
   font-size: 18px !important;
   color: #ffefd6;
 }
@@ -1371,6 +1407,10 @@ exports[`<Tag /> onClose Prop is rendering well 10`] = `
   color: #fff5f5;
 }
 
+.c5 {
+  width: 24px;
+}
+
 <div
   className="c0"
   size="medium"
@@ -1387,7 +1427,7 @@ exports[`<Tag /> onClose Prop is rendering well 10`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1448,49 +1488,53 @@ exports[`<Tag /> onClose Prop is rendering well 11`] = `
   color: #424242;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #dcedc8;
 }
 
-.c12 .c3 {
+.c13 .c3 {
   font-size: 18px !important;
   color: #ffefd6;
 }
 
-.c13 .c3 {
+.c14 .c3 {
   font-size: 18px !important;
   color: #fff5f5;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -1509,7 +1553,7 @@ exports[`<Tag /> onClose Prop is rendering well 11`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1556,7 +1600,7 @@ exports[`<Tag /> onClose Prop is rendering well 12`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
@@ -1575,44 +1619,48 @@ exports[`<Tag /> onClose Prop is rendering well 12`] = `
   color: #1250C4;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #dcedc8;
 }
 
-.c12 .c3 {
+.c13 .c3 {
   font-size: 18px !important;
   color: #ffefd6;
 }
 
-.c13 .c3 {
+.c14 .c3 {
   font-size: 18px !important;
   color: #fff5f5;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -1631,7 +1679,7 @@ exports[`<Tag /> onClose Prop is rendering well 12`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1678,12 +1726,12 @@ exports[`<Tag /> onClose Prop is rendering well 13`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
@@ -1702,39 +1750,43 @@ exports[`<Tag /> onClose Prop is rendering well 13`] = `
   color: #004D40;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #dcedc8;
 }
 
-.c12 .c3 {
+.c13 .c3 {
   font-size: 18px !important;
   color: #ffefd6;
 }
 
-.c13 .c3 {
+.c14 .c3 {
   font-size: 18px !important;
   color: #fff5f5;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -1753,7 +1805,7 @@ exports[`<Tag /> onClose Prop is rendering well 13`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1800,17 +1852,17 @@ exports[`<Tag /> onClose Prop is rendering well 14`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
@@ -1829,34 +1881,38 @@ exports[`<Tag /> onClose Prop is rendering well 14`] = `
   color: #d14900;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #ac001a;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #dcedc8;
 }
 
-.c12 .c3 {
+.c13 .c3 {
   font-size: 18px !important;
   color: #ffefd6;
 }
 
-.c13 .c3 {
+.c14 .c3 {
   font-size: 18px !important;
   color: #fff5f5;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -1875,7 +1931,7 @@ exports[`<Tag /> onClose Prop is rendering well 14`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={
@@ -1922,22 +1978,22 @@ exports[`<Tag /> onClose Prop is rendering well 15`] = `
   width: 18px;
 }
 
-.c5 .c3 {
+.c6 .c3 {
   font-size: 18px !important;
   color: #424242;
 }
 
-.c6 .c3 {
+.c7 .c3 {
   font-size: 18px !important;
   color: #1250C4;
 }
 
-.c7 .c3 {
+.c8 .c3 {
   font-size: 18px !important;
   color: #004D40;
 }
 
-.c8 .c3 {
+.c9 .c3 {
   font-size: 18px !important;
   color: #d14900;
 }
@@ -1956,29 +2012,33 @@ exports[`<Tag /> onClose Prop is rendering well 15`] = `
   color: #ac001a;
 }
 
-.c9 .c3 {
+.c10 .c3 {
   font-size: 18px !important;
   color: #f2f2f2;
 }
 
-.c10 .c3 {
+.c11 .c3 {
   font-size: 18px !important;
   color: #E5EDFC;
 }
 
-.c11 .c3 {
+.c12 .c3 {
   font-size: 18px !important;
   color: #dcedc8;
 }
 
-.c12 .c3 {
+.c13 .c3 {
   font-size: 18px !important;
   color: #ffefd6;
 }
 
-.c13 .c3 {
+.c14 .c3 {
   font-size: 18px !important;
   color: #fff5f5;
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -1997,7 +2057,7 @@ exports[`<Tag /> onClose Prop is rendering well 15`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root c3 c4"
+        className="MuiSvgIcon-root c3 c4 c5"
         focusable="false"
         role="presentation"
         style={

--- a/components/Tag/__snapshots__/Tag.unit.test.jsx.snap
+++ b/components/Tag/__snapshots__/Tag.unit.test.jsx.snap
@@ -454,7 +454,7 @@ exports[`<Tag /> onClose Prop is rendering well 1`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -540,7 +540,7 @@ exports[`<Tag /> onClose Prop is rendering well 2`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -631,7 +631,7 @@ exports[`<Tag /> onClose Prop is rendering well 3`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -727,7 +727,7 @@ exports[`<Tag /> onClose Prop is rendering well 4`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -828,7 +828,7 @@ exports[`<Tag /> onClose Prop is rendering well 5`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -934,7 +934,7 @@ exports[`<Tag /> onClose Prop is rendering well 6`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1045,7 +1045,7 @@ exports[`<Tag /> onClose Prop is rendering well 7`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1161,7 +1161,7 @@ exports[`<Tag /> onClose Prop is rendering well 8`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1282,7 +1282,7 @@ exports[`<Tag /> onClose Prop is rendering well 9`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1408,7 +1408,7 @@ exports[`<Tag /> onClose Prop is rendering well 10`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1534,7 +1534,7 @@ exports[`<Tag /> onClose Prop is rendering well 11`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1660,7 +1660,7 @@ exports[`<Tag /> onClose Prop is rendering well 12`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1786,7 +1786,7 @@ exports[`<Tag /> onClose Prop is rendering well 13`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -1912,7 +1912,7 @@ exports[`<Tag /> onClose Prop is rendering well 14`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -2038,7 +2038,7 @@ exports[`<Tag /> onClose Prop is rendering well 15`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div

--- a/components/Toggle/__snapshots__/Toggle.unit.test.jsx.snap
+++ b/components/Toggle/__snapshots__/Toggle.unit.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`<Toggle />  Snapshots should match snapshot with checked prop 1`] = `
 }
 
 .c3 .c4,
-.c3 .c5 {
+.c3 .c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -86,7 +86,7 @@ exports[`<Toggle />  Snapshots should match snapshot with checked prop 1`] = `
   transform: translateX(18px);
 }
 
-.c1:checked + .c2 .c5 {
+.c1:checked + .c2 .c6 {
   visibility: visible;
 }
 
@@ -98,12 +98,16 @@ exports[`<Toggle />  Snapshots should match snapshot with checked prop 1`] = `
   background-color: #002F7B;
 }
 
-.c1:checked + .c2 .c5 {
+.c1:checked + .c2 .c6 {
   background-color: #E5EDFC;
   color: #1250C4;
   -webkit-transform: translateX(18px);
   -ms-transform: translateX(18px);
   transform: translateX(18px);
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -121,7 +125,7 @@ exports[`<Toggle />  Snapshots should match snapshot with checked prop 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c4 "
+      className="MuiSvgIcon-root c4 c5"
       focusable="false"
       role="presentation"
       style={
@@ -138,7 +142,7 @@ exports[`<Toggle />  Snapshots should match snapshot with checked prop 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c5 "
+      className="MuiSvgIcon-root c6 c5"
       focusable="false"
       role="presentation"
       style={
@@ -186,7 +190,7 @@ exports[`<Toggle />  Snapshots should match snapshot without props 1`] = `
 }
 
 .c3 .c4,
-.c3 .c5 {
+.c3 .c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -243,7 +247,7 @@ exports[`<Toggle />  Snapshots should match snapshot without props 1`] = `
   transform: translateX(18px);
 }
 
-.c1:checked + .c2 .c5 {
+.c1:checked + .c2 .c6 {
   visibility: visible;
 }
 
@@ -255,12 +259,16 @@ exports[`<Toggle />  Snapshots should match snapshot without props 1`] = `
   background-color: #002F7B;
 }
 
-.c1:checked + .c2 .c5 {
+.c1:checked + .c2 .c6 {
   background-color: #E5EDFC;
   color: #1250C4;
   -webkit-transform: translateX(18px);
   -ms-transform: translateX(18px);
   transform: translateX(18px);
+}
+
+.c5 {
+  width: 24px;
 }
 
 <div
@@ -278,7 +286,7 @@ exports[`<Toggle />  Snapshots should match snapshot without props 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c4 "
+      className="MuiSvgIcon-root c4 c5"
       focusable="false"
       role="presentation"
       style={
@@ -295,7 +303,7 @@ exports[`<Toggle />  Snapshots should match snapshot without props 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      className="MuiSvgIcon-root c5 "
+      className="MuiSvgIcon-root c6 c5"
       focusable="false"
       role="presentation"
       style={

--- a/components/Toggle/__snapshots__/Toggle.unit.test.jsx.snap
+++ b/components/Toggle/__snapshots__/Toggle.unit.test.jsx.snap
@@ -107,7 +107,7 @@ exports[`<Toggle />  Snapshots should match snapshot with checked prop 1`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div
@@ -268,7 +268,7 @@ exports[`<Toggle />  Snapshots should match snapshot without props 1`] = `
 }
 
 .c5 {
-  width: 24px;
+  width: 0px;
 }
 
 <div


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/3389749/79272798-537b8280-7e78-11ea-8d93-f157e2ea9953.png)

This occurs because the css of the material loads after the render of svgs.
To avoid this, was putted a default size (0px) on pre loading process, for the svg icons doesnt break the layout.

⚠️ If your testing in catho-components, the icons still are loading in the wrong way, update the Quantum in node_modules of catho-components with the last build you made

## Setup
To simulate, build the Quantum and import in another application.

- [ ] Testing all the components in SSR (quantum-react-app)
- [ ] Testing some components in CSR (create-react-app)
- [ ] In application, import any Icon and simulate how its loading.

## Review guide
- [x] Unit tests (yarn test:components)
- [x] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [x] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome