### PR TITLE
feat(Pagination): Allow onClick event return in onClick handler function

### DIFF
--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -48,7 +48,7 @@ class Pagination extends React.Component {
         return false;
       }
 
-      return onPageClick(page);
+      return onPageClick(page, e);
     };
 
     const handleHref = page => {

--- a/components/Pagination/Pagination.unit.test.jsx
+++ b/components/Pagination/Pagination.unit.test.jsx
@@ -97,7 +97,7 @@ describe('<Pagination />', () => {
           .at(2)
           .simulate('click');
 
-        expect(onPageClickMock).toHaveBeenCalledWith(3);
+        expect(onPageClickMock).toHaveBeenCalledWith(3, expect.any(Object));
       });
     });
 
@@ -145,7 +145,7 @@ describe('<Pagination />', () => {
           .at(0)
           .simulate('click');
 
-        expect(onPageClickMock).toHaveBeenCalledWith(1);
+        expect(onPageClickMock).toHaveBeenCalledWith(1, expect.any(Object));
       });
 
       it('should receive next page as onClick parameter when next button is clicked', () => {
@@ -163,7 +163,7 @@ describe('<Pagination />', () => {
           .at(1)
           .simulate('click');
 
-        expect(onPageClickMock).toHaveBeenCalledWith(3);
+        expect(onPageClickMock).toHaveBeenCalledWith(3, expect.any(Object));
       });
     });
   });

--- a/stories/Pagination/Pagination.story.jsx
+++ b/stories/Pagination/Pagination.story.jsx
@@ -231,17 +231,18 @@ storiesOf('Pagination', module).add('Pagination', () => (
             </Col>
           </Row>
 
-          <Title as="h3">onClickPage prop</Title>
+          <Title as="h3">onPageClick prop</Title>
           <p>
-            Through <code>onClickPage</code> prop is possible to get the page
+            Through <code>onPageClick</code> prop is possible to get the page
             clicked.
           </p>
           <p>
             This prop must be a function and it{' '}
-            <strong>receives the page clicked number</strong>.
+            <strong>receives the page clicked number and a event</strong> (open
+            console, click in the pages and see).
           </p>
           <p>
-            If you set <code>onClickPage</code> prop the <code>pageHref</code>{' '}
+            If you set <code>onPageClick</code> prop the <code>pageHref</code>{' '}
             prop will be ignored.
           </p>
           <p>

--- a/stories/Pagination/examples/ControlledPagination.jsx
+++ b/stories/Pagination/examples/ControlledPagination.jsx
@@ -11,7 +11,8 @@ class ControlledPagination extends Component {
     };
   }
 
-  handleClick = nextPage => {
+  handleClick = (nextPage, event) => {
+    console.log(event.target);
     this.setState({ activePage: nextPage });
   };
 
@@ -40,7 +41,8 @@ class ControlledPagination extends Component {
     };
   }
 
-  handleClick = nextPage => {
+  handleClick = (nextPage, event) => {
+    console.log(event);
     this.setState({ activePage: nextPage });
   };
 


### PR DESCRIPTION
## Description
This change allow all user of the Quantum to receive event of the onclick in handler function pass by the prop "onPageClick"

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [x] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [x] Unit tests (yarn test:components)
- [x] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [x] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation