### PR TITLE
build(dependencies): Moving quantum-storybook-ui to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,10 +104,10 @@
     "regenerator-runtime": "^0.13.1",
     "semantic-release": "^15.13.3",
     "strip-ansi": "^5.0.0",
-    "styled-components": "^5.0.1"
+    "styled-components": "^5.0.1",
+    "@catho/quantum-storybook-ui": "^1.2.3"
   },
   "dependencies": {
-    "@catho/quantum-storybook-ui": "^1.2.3",
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^4.9.1",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
fix #247

## Description
Put the description of the task here.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [x] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [x] Unit tests (yarn test:components)
- [x] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [x] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation