### PR TITLE
fix(Radio button): fixes the text align when the label breaks line

### DIFF
--- a/components/RadioGroup/Radio.jsx
+++ b/components/RadioGroup/Radio.jsx
@@ -9,7 +9,7 @@ const radioSize = '24px';
 const RadioMark = styled.span`
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  flex: 0 0 auto;
   height: ${radioSize};
   position: relative;
   top: 6px;
@@ -49,9 +49,11 @@ const RadioMark = styled.span`
 `;
 
 const RadioLabel = styled(Label)`
+  align-items: baseline;
+  display: flex;
   cursor: pointer;
   user-select: none;
-
+  
   ${HiddenInput} {
     :checked {
       ~ ${RadioMark} {
@@ -242,7 +244,7 @@ const Radio = ({
       {...rest}
     />
     <RadioMark theme={theme} />
-    {children || label}
+    <span>{children || label}</span>
   </RadioLabel>
 );
 

--- a/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
@@ -15,7 +15,9 @@ exports[`<RadioGroup.Radio /> snapshot children 1`] = `
 .c4 {
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 24px;
   position: relative;
   top: 6px;
@@ -40,97 +42,14 @@ exports[`<RadioGroup.Radio /> snapshot children 1`] = `
 .c0 {
   display: block;
   margin-bottom: 5px;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c0 .c1:checked ~ .c3 {
-  border-color: #1250C4;
-}
-
-.c0 .c1:checked ~ .c3:after {
-  background-color: #1250C4;
-  display: block;
-}
-
-.c0 .c1:focus ~ .c3 {
-  border-color: #1250C4;
-  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
-}
-
-.c0:hover .c3,
-.c0:focus .c3 {
-  border-color: #1250C4;
-  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
-}
-
-.c0 .c1:checked:disabled ~ .c3 {
-  background-color: #999999;
-  border-color: #999999;
-  box-shadow: inset 0 0 0 3.5px #ffffff;
-}
-
-<label
-  className="Label-sc-1ny5bqy-0 c0"
-  disabled={false}
->
-  <input
-    className="c1 c2"
-    disabled={false}
-    onChange={[Function]}
-    type="radio"
-    value="Foo"
-  />
-  <span
-    className="c3 c4"
-  />
-  Foo
-</label>
-`;
-
-exports[`<RadioGroup.Radio /> snapshot children with element 1`] = `
-.c2 {
-  border: 0;
-  height: 0;
-  margin: 0;
-  opacity: 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 0;
-}
-
-.c4 {
-  border-radius: 50%;
-  box-sizing: border-box;
-  display: inline-block;
-  height: 24px;
-  position: relative;
-  top: 6px;
-  width: 24px;
-  background-color: #ffffff;
-  border: 2px solid #999999;
-  margin-right: 8px;
-}
-
-.c4:after {
-  border-radius: 50%;
-  content: '';
-  display: none;
-  height: 60%;
-  left: 20%;
-  position: absolute;
-  top: 20%;
-  width: 60%;
-  background-color: #1250C4;
-}
-
-.c0 {
-  display: block;
-  margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -184,7 +103,7 @@ exports[`<RadioGroup.Radio /> snapshot children with element 1`] = `
 </label>
 `;
 
-exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
+exports[`<RadioGroup.Radio /> snapshot children with element 1`] = `
 .c2 {
   border: 0;
   height: 0;
@@ -199,7 +118,9 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
 .c4 {
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 24px;
   position: relative;
   top: 6px;
@@ -224,6 +145,119 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
 .c0 {
   display: block;
   margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c0 .c1:checked ~ .c3 {
+  border-color: #1250C4;
+}
+
+.c0 .c1:checked ~ .c3:after {
+  background-color: #1250C4;
+  display: block;
+}
+
+.c0 .c1:focus ~ .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c0:hover .c3,
+.c0:focus .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c0 .c1:checked:disabled ~ .c3 {
+  background-color: #999999;
+  border-color: #999999;
+  box-shadow: inset 0 0 0 3.5px #ffffff;
+}
+
+<label
+  className="Label-sc-1ny5bqy-0 c0"
+  disabled={false}
+>
+  <input
+    className="c1 c2"
+    disabled={false}
+    onChange={[Function]}
+    type="radio"
+    value="Foo"
+  />
+  <span
+    className="c3 c4"
+  />
+  <span>
+    <span>
+      Foo
+    </span>
+  </span>
+</label>
+`;
+
+exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
+.c2 {
+  border: 0;
+  height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 0;
+}
+
+.c4 {
+  border-radius: 50%;
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  height: 24px;
+  position: relative;
+  top: 6px;
+  width: 24px;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  margin-right: 8px;
+}
+
+.c4:after {
+  border-radius: 50%;
+  content: '';
+  display: none;
+  height: 60%;
+  left: 20%;
+  position: absolute;
+  top: 20%;
+  width: 60%;
+  background-color: #1250C4;
+}
+
+.c0 {
+  display: block;
+  margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -309,7 +343,9 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
   <span
     className="c3 c4"
   />
-  Foo
+  <span>
+    Foo
+  </span>
 </label>
 `;
 
@@ -328,7 +364,9 @@ exports[`<RadioGroup.Radio /> snapshot error 1`] = `
 .c4 {
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 24px;
   position: relative;
   top: 6px;
@@ -353,6 +391,14 @@ exports[`<RadioGroup.Radio /> snapshot error 1`] = `
 .c0 {
   display: block;
   margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -424,7 +470,9 @@ exports[`<RadioGroup.Radio /> snapshot error 1`] = `
   <span
     className="c3 c4"
   />
-  Foo
+  <span>
+    Foo
+  </span>
 </label>
 `;
 
@@ -443,7 +491,9 @@ exports[`<RadioGroup.Radio /> snapshot simple 1`] = `
 .c4 {
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 24px;
   position: relative;
   top: 6px;
@@ -468,6 +518,14 @@ exports[`<RadioGroup.Radio /> snapshot simple 1`] = `
 .c0 {
   display: block;
   margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -515,6 +573,8 @@ exports[`<RadioGroup.Radio /> snapshot simple 1`] = `
   <span
     className="c3 c4"
   />
-  Foo
+  <span>
+    Foo
+  </span>
 </label>
 `;

--- a/components/RadioGroup/__snapshots__/RadioGroup.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/RadioGroup.unit.test.jsx.snap
@@ -471,7 +471,9 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
 .c5 {
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 24px;
   position: relative;
   top: 6px;
@@ -496,6 +498,14 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
 .c1 {
   display: block;
   margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -557,7 +567,9 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
     <span
       className="c4 c5"
     />
-    Foo
+    <span>
+      Foo
+    </span>
   </label>
   <label
     className="Label-sc-1ny5bqy-0 c1"
@@ -575,7 +587,9 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
     <span
       className="c4 c5"
     />
-    Bar
+    <span>
+      Bar
+    </span>
   </label>
   <label
     className="Label-sc-1ny5bqy-0 c1"
@@ -593,7 +607,9 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
     <span
       className="c4 c5"
     />
-    Baz
+    <span>
+      Baz
+    </span>
   </label>
 </div>
 `;
@@ -783,7 +799,9 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
 .c5 {
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 24px;
   position: relative;
   top: 6px;
@@ -808,6 +826,14 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
 .c1 {
   display: block;
   margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -869,7 +895,9 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
     <span
       className="c4 c5"
     />
-    Foo
+    <span>
+      Foo
+    </span>
   </label>
   <label
     className="Label-sc-1ny5bqy-0 c1"
@@ -887,7 +915,9 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
     <span
       className="c4 c5"
     />
-    Bar
+    <span>
+      Bar
+    </span>
   </label>
   <label
     className="Label-sc-1ny5bqy-0 c1"
@@ -905,7 +935,9 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
     <span
       className="c4 c5"
     />
-    Baz
+    <span>
+      Baz
+    </span>
   </label>
 </div>
 `;
@@ -936,7 +968,9 @@ exports[`<RadioGroup /> snapshot with an error 1`] = `
 .c5 {
   border-radius: 50%;
   box-sizing: border-box;
-  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 24px;
   position: relative;
   top: 6px;
@@ -961,6 +995,14 @@ exports[`<RadioGroup /> snapshot with an error 1`] = `
 .c1 {
   display: block;
   margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -1046,7 +1088,9 @@ exports[`<RadioGroup /> snapshot with an error 1`] = `
     <span
       className="c4 c5"
     />
-    Foo
+    <span>
+      Foo
+    </span>
   </label>
   <span
     className="c6"


### PR DESCRIPTION
## Description
reference: 
![image](https://user-images.githubusercontent.com/3389749/91219348-dfd46680-e6f0-11ea-834e-d3a7424d510e.png)

earlier:
![image](https://user-images.githubusercontent.com/3389749/91219688-6b4df780-e6f1-11ea-9168-8958523dc984.png)

now:
![image](https://user-images.githubusercontent.com/3389749/91219415-fd093500-e6f0-11ea-89bb-64c3548ed331.png)


## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation