### PR TITLE
fix(RadioGroup): use defaultChecked for predefined radio group values

### DIFF
--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -22,7 +22,7 @@ const RadioGroup = ({
   name,
   onChange,
   options,
-  value,
+  defaultValue,
   theme,
   ...rest
 }) => {
@@ -33,10 +33,11 @@ const RadioGroup = ({
     onChange,
     inline,
   };
+
   const radioOptions = options.map(option =>
     Object.assign({}, option, {
       key: option.value,
-      checked: option.value === value ? true : undefined,
+      defaultChecked: option.value === defaultValue ? true : undefined,
       ...commonProps,
     }),
   );
@@ -44,7 +45,7 @@ const RadioGroup = ({
   const items =
     React.Children.map(children, child =>
       React.cloneElement(child, {
-        checked: child.props.value === value ? true : undefined,
+        defaultChecked: child.props.value === defaultValue ? true : undefined,
         ...commonProps,
       }),
     ) ||
@@ -80,7 +81,7 @@ RadioGroup.propTypes = {
   inline: PropTypes.bool,
   onChange: PropTypes.func,
   /** Initialize RadioGroup with a value */
-  value: PropTypes.string,
+  defaultValue: PropTypes.string,
   name: PropTypes.string.isRequired,
   error: PropTypes.string,
   theme: PropTypes.shape({
@@ -100,7 +101,7 @@ RadioGroup.defaultProps = {
   inline: false,
   onChange: () => {},
   options: [],
-  value: undefined,
+  defaultValue: undefined,
   theme: { colors, spacing },
 };
 

--- a/components/RadioGroup/RadioGroup.unit.test.jsx
+++ b/components/RadioGroup/RadioGroup.unit.test.jsx
@@ -41,9 +41,9 @@ const _childrenTest = RadioItem => {
 
     it(`should have <${
       RadioItem.displayName
-    } /> checked matching <RadioGroup /> value`, () => {
+    } /> defaultChecked matching <RadioGroup /> defaultValue`, () => {
       const component = (
-        <RadioGroup name="foo" value="Bar">
+        <RadioGroup name="foo" defaultValue="Bar">
           <RadioItem value="Foo">Foo</RadioItem>
           <RadioItem value="Bar">Bar</RadioItem>
           <RadioItem value="Baz">Baz</RadioItem>
@@ -53,7 +53,7 @@ const _childrenTest = RadioItem => {
       const radios = wrapper.find(RadioItem);
 
       const radioBar = radios.at(1);
-      expect(radioBar.prop('checked')).toBe(true);
+      expect(radioBar.prop('defaultChecked')).toBe(true);
     });
 
     it(`should call onChange on every <${RadioItem.displayName} />`, () => {

--- a/stories/RadioGroup/RadioGroup.story.jsx
+++ b/stories/RadioGroup/RadioGroup.story.jsx
@@ -76,7 +76,7 @@ stories.add('Radio group', () => (
 
           <p>
             Also, you can set some properties to <code>RadioGroup</code>, such
-            as the selected <code>value</code>, <code>error</code> and{' '}
+            as the selected <code>defaultValue</code>, <code>error</code> and{' '}
             <code>onChange</code> function
           </p>
           <br />

--- a/stories/RadioGroup/sub-components/propsRadioGroup.jsx
+++ b/stories/RadioGroup/sub-components/propsRadioGroup.jsx
@@ -10,14 +10,14 @@ const options = [
 const propsRadioGroup = {
   code: `<RadioGroup 
   name="groceries" 
-  value="Barbecue sauce"> 
+  defaultValue="Barbecue sauce"> 
   ... 
 </RadioGroup>
 
 <RadioGroup 
   name="groceries" 
   error="Required"> 
-    ...
+  ...
 </RadioGroup>
 
 <RadioGroup 
@@ -30,9 +30,10 @@ const propsRadioGroup = {
     <>
       <RadioGroup
         name="groceries_selected"
-        value="Barbecue sauce"
+        defaultValue="Barbecue sauce"
         options={options}
       />
+
       <RadioGroup name="groceries_error" error="Required" options={options} />
 
       <RadioGroup


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-215

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
 - [ ] Edge
 - [ ] Firefox
 - [ ] Chrome
 - [ ] Safari
 - [ ] Mobile

### Application Test
 - [ ] Test within a form