### PR TITLE
feat(required-radio-group): Add property "required" to the RadioGroup component

### DIFF
--- a/components/RadioGroup/Radio.jsx
+++ b/components/RadioGroup/Radio.jsx
@@ -233,6 +233,7 @@ const Radio = ({
   onChange,
   value,
   theme,
+  required,
   ...rest
 }) => (
   <RadioLabel error={error} disabled={disabled} theme={theme}>
@@ -241,6 +242,7 @@ const Radio = ({
       disabled={disabled}
       onChange={e => onChange({ value, label }, e)}
       value={value}
+      required={required}
       {...rest}
     />
     <RadioMark theme={theme} />

--- a/components/RadioGroup/Radio.jsx
+++ b/components/RadioGroup/Radio.jsx
@@ -273,6 +273,7 @@ Radio.defaultProps = {
   label: undefined,
   onChange: () => {},
   theme: { colors, spacing },
+  required: false,
 };
 
 export default Radio;

--- a/components/RadioGroup/Radio.jsx
+++ b/components/RadioGroup/Radio.jsx
@@ -263,6 +263,7 @@ Radio.propTypes = {
     colors: PropTypes.object,
     spacing: PropTypes.object,
   }),
+  required: PropTypes.bool,
 };
 
 Radio.defaultProps = {

--- a/components/RadioGroup/Radio.unit.test.jsx
+++ b/components/RadioGroup/Radio.unit.test.jsx
@@ -32,5 +32,14 @@ describe('<RadioGroup.Radio />', () => {
       );
       expect(renderer.create(component).toJSON()).toMatchSnapshot();
     });
+
+    it('required', () => {
+      const component = (
+        <Radio value="Foo" required>
+          Foo
+        </Radio>
+      );
+      expect(renderer.create(component).toJSON()).toMatchSnapshot();
+    });
   });
 });

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -90,6 +90,7 @@ RadioGroup.propTypes = {
     colors: PropTypes.object,
     spacing: PropTypes.object,
   }),
+  required: PropTypes.bool,
 };
 
 /**

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -24,6 +24,7 @@ const RadioGroup = ({
   options,
   defaultValue,
   theme,
+  required,
   ...rest
 }) => {
   const commonProps = {
@@ -32,6 +33,7 @@ const RadioGroup = ({
     error: Boolean(error),
     onChange,
     inline,
+    required,
   };
 
   const radioOptions = options.map(option =>

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -106,6 +106,7 @@ RadioGroup.defaultProps = {
   options: [],
   defaultValue: undefined,
   theme: { colors, spacing },
+  required: false,
 };
 
 export default RadioGroup;

--- a/components/RadioGroup/RadioGroup.unit.test.jsx
+++ b/components/RadioGroup/RadioGroup.unit.test.jsx
@@ -196,6 +196,15 @@ describe('<RadioGroup />', () => {
         `Snapshot Diff:\n ${stripAnsi(diff(snapOptions, snapComposable))}`,
       ).toMatchSnapshot();
     });
+
+    it('with required', () => {
+      const component = (
+        <RadioGroup name="groceries" required>
+          <RadioGroup.Radio value="Foo">Foo</RadioGroup.Radio>
+        </RadioGroup>
+      );
+      expect(renderer.create(component)).toMatchSnapshot();
+    });
   });
 
   _childrenTest(RadioGroup.Radio);

--- a/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
@@ -91,6 +91,7 @@ exports[`<RadioGroup.Radio /> snapshot children 1`] = `
     className="c1 c2"
     disabled={false}
     onChange={[Function]}
+    required={false}
     type="radio"
     value="Foo"
   />
@@ -194,6 +195,7 @@ exports[`<RadioGroup.Radio /> snapshot children with element 1`] = `
     className="c1 c2"
     disabled={false}
     onChange={[Function]}
+    required={false}
     type="radio"
     value="Foo"
   />
@@ -337,6 +339,7 @@ exports[`<RadioGroup.Radio /> snapshot disabled 1`] = `
     className="c1 c2"
     disabled={true}
     onChange={[Function]}
+    required={false}
     type="radio"
     value="Foo"
   />
@@ -464,6 +467,7 @@ exports[`<RadioGroup.Radio /> snapshot error 1`] = `
     className="c1 c2"
     disabled={false}
     onChange={[Function]}
+    required={false}
     type="radio"
     value="Foo"
   />
@@ -671,6 +675,7 @@ exports[`<RadioGroup.Radio /> snapshot simple 1`] = `
     className="c1 c2"
     disabled={false}
     onChange={[Function]}
+    required={false}
     type="radio"
     value="Foo"
   />

--- a/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/Radio.unit.test.jsx.snap
@@ -476,6 +476,110 @@ exports[`<RadioGroup.Radio /> snapshot error 1`] = `
 </label>
 `;
 
+exports[`<RadioGroup.Radio /> snapshot required 1`] = `
+.c2 {
+  border: 0;
+  height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 0;
+}
+
+.c4 {
+  border-radius: 50%;
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  height: 24px;
+  position: relative;
+  top: 6px;
+  width: 24px;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  margin-right: 8px;
+}
+
+.c4:after {
+  border-radius: 50%;
+  content: '';
+  display: none;
+  height: 60%;
+  left: 20%;
+  position: absolute;
+  top: 20%;
+  width: 60%;
+  background-color: #1250C4;
+}
+
+.c0 {
+  display: block;
+  margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c0 .c1:checked ~ .c3 {
+  border-color: #1250C4;
+}
+
+.c0 .c1:checked ~ .c3:after {
+  background-color: #1250C4;
+  display: block;
+}
+
+.c0 .c1:focus ~ .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c0:hover .c3,
+.c0:focus .c3 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c0 .c1:checked:disabled ~ .c3 {
+  background-color: #999999;
+  border-color: #999999;
+  box-shadow: inset 0 0 0 3.5px #ffffff;
+}
+
+<label
+  className="Label-sc-1ny5bqy-0 c0"
+  disabled={false}
+>
+  <input
+    className="c1 c2"
+    disabled={false}
+    onChange={[Function]}
+    required={true}
+    type="radio"
+    value="Foo"
+  />
+  <span
+    className="c3 c4"
+  />
+  <span>
+    Foo
+  </span>
+</label>
+`;
+
 exports[`<RadioGroup.Radio /> snapshot simple 1`] = `
 .c2 {
   border: 0;

--- a/components/RadioGroup/__snapshots__/RadioGroup.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/RadioGroup.unit.test.jsx.snap
@@ -36,6 +36,7 @@ exports[`<RadioGroup /> snapshot should render the same, with <RadioGroup.Button
 +         id=\\"radio-button-12\\"
           name=\\"foo\\"
           onChange={[Function onChange]}
+          required={false}
           type=\\"radio\\"
           value=\\"Foo\\"
         />
@@ -64,6 +65,7 @@ exports[`<RadioGroup /> snapshot should render the same, with <RadioGroup.Button
 +         id=\\"radio-button-13\\"
           name=\\"foo\\"
           onChange={[Function onChange]}
+          required={false}
           type=\\"radio\\"
           value=\\"Bar\\"
         />
@@ -92,6 +94,7 @@ exports[`<RadioGroup /> snapshot should render the same, with <RadioGroup.Button
 +         id=\\"radio-button-14\\"
           name=\\"foo\\"
           onChange={[Function onChange]}
+          required={false}
           type=\\"radio\\"
           value=\\"Baz\\"
         />
@@ -210,6 +213,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Button /> 1`] = `
         id="radio-button-3"
         name="groceries"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Foo"
       />
@@ -236,6 +240,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Button /> 1`] = `
         id="radio-button-4"
         name="groceries"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Bar"
       />
@@ -262,6 +267,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Button /> 1`] = `
         id="radio-button-5"
         name="groceries"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Baz"
       />
@@ -395,6 +401,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Button /> inline 1`] = 
         id="radio-button-6"
         name="groceries"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Foo"
       />
@@ -421,6 +428,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Button /> inline 1`] = 
         id="radio-button-7"
         name="groceries"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Bar"
       />
@@ -447,6 +455,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Button /> inline 1`] = 
         id="radio-button-8"
         name="groceries"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Baz"
       />
@@ -560,6 +569,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
       disabled={false}
       name="groceries"
       onChange={[Function]}
+      required={false}
       size="medium"
       type="radio"
       value="Foo"
@@ -580,6 +590,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
       disabled={false}
       name="groceries"
       onChange={[Function]}
+      required={false}
       size="medium"
       type="radio"
       value="Bar"
@@ -600,6 +611,7 @@ exports[`<RadioGroup /> snapshot simple with <RadioGroup.Radio /> 1`] = `
       disabled={false}
       name="groceries"
       onChange={[Function]}
+      required={false}
       size="medium"
       type="radio"
       value="Baz"
@@ -723,6 +735,7 @@ exports[`<RadioGroup /> snapshot simple with button options 1`] = `
         id="radio-button-0"
         name="foo"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Foo"
       />
@@ -749,6 +762,7 @@ exports[`<RadioGroup /> snapshot simple with button options 1`] = `
         id="radio-button-1"
         name="foo"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Bar"
       />
@@ -775,6 +789,7 @@ exports[`<RadioGroup /> snapshot simple with button options 1`] = `
         id="radio-button-2"
         name="foo"
         onChange={[Function]}
+        required={false}
         type="radio"
         value="Baz"
       />
@@ -888,6 +903,7 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
       disabled={false}
       name="foo"
       onChange={[Function]}
+      required={false}
       size="medium"
       type="radio"
       value="Foo"
@@ -908,6 +924,7 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
       disabled={false}
       name="foo"
       onChange={[Function]}
+      required={false}
       size="medium"
       type="radio"
       value="Bar"
@@ -928,6 +945,7 @@ exports[`<RadioGroup /> snapshot simple with options 1`] = `
       disabled={false}
       name="foo"
       onChange={[Function]}
+      required={false}
       size="medium"
       type="radio"
       value="Baz"
@@ -1081,6 +1099,7 @@ exports[`<RadioGroup /> snapshot with an error 1`] = `
       disabled={false}
       name="groceries"
       onChange={[Function]}
+      required={false}
       size="medium"
       type="radio"
       value="Foo"

--- a/components/RadioGroup/__snapshots__/RadioGroup.unit.test.jsx.snap
+++ b/components/RadioGroup/__snapshots__/RadioGroup.unit.test.jsx.snap
@@ -1099,3 +1099,122 @@ exports[`<RadioGroup /> snapshot with an error 1`] = `
   </span>
 </div>
 `;
+
+exports[`<RadioGroup /> snapshot with required 1`] = `
+.c3 {
+  border: 0;
+  height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 0;
+}
+
+.c5 {
+  border-radius: 50%;
+  box-sizing: border-box;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  height: 24px;
+  position: relative;
+  top: 6px;
+  width: 24px;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  margin-right: 8px;
+}
+
+.c5:after {
+  border-radius: 50%;
+  content: '';
+  display: none;
+  height: 60%;
+  left: 20%;
+  position: absolute;
+  top: 20%;
+  width: 60%;
+  background-color: #1250C4;
+}
+
+.c1 {
+  display: block;
+  margin-bottom: 5px;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c1 .c2:checked ~ .c4 {
+  border-color: #1250C4;
+}
+
+.c1 .c2:checked ~ .c4:after {
+  background-color: #1250C4;
+  display: block;
+}
+
+.c1 .c2:focus ~ .c4 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c1:hover .c4,
+.c1:focus .c4 {
+  border-color: #1250C4;
+  box-shadow: 0px 3px 5px -1px rgba(18,80,196,0.2),0px 5px 8px 0px rgba(18,80,196,0.14),0px 1px 14px 0px rgba(18,80,196,0.12);
+}
+
+.c1 .c2:checked:disabled ~ .c4 {
+  background-color: #999999;
+  border-color: #999999;
+  box-shadow: inset 0 0 0 3.5px #ffffff;
+}
+
+.c0 {
+  position: relative;
+  margin-bottom: 20px;
+  min-width: 250px;
+  width: 100%;
+  position: relative;
+}
+
+<div
+  className="FieldGroup-sc-18uoi37-0 c0"
+  role="radiogroup"
+>
+  <label
+    className="Label-sc-1ny5bqy-0 c1"
+    disabled={false}
+  >
+    <input
+      className="c2 c3"
+      disabled={false}
+      name="groceries"
+      onChange={[Function]}
+      required={true}
+      size="medium"
+      type="radio"
+      value="Foo"
+    />
+    <span
+      className="c4 c5"
+    />
+    <span>
+      Foo
+    </span>
+  </label>
+</div>
+`;


### PR DESCRIPTION
## Description
Was added a property required to the component Radio and RadioGroup.
That need came because we need valid radio as "required" in form and didn't have that prop before.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [x] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation