### PR TITLE
Updating Cards and Modal type

### DIFF
--- a/components/Card/index.d.ts
+++ b/components/Card/index.d.ts
@@ -9,10 +9,12 @@ import Thumbnail from './Thumbnail';
 import Title from './Title';
 
 type Props = {
-	theme?: {
-		colors?: object
-	}
+    onClick?: (e: React.MouseEvent) => void;
+    theme?: {
+        colors?: object
+    }
 }
+
 export default class Card extends React.Component<Props> {
     static Content: Content;
 

--- a/components/Modal/index.d.ts
+++ b/components/Modal/index.d.ts
@@ -13,6 +13,7 @@ export type ModalContent = React.ComponentType<StaticProps>;
 
 export interface ModalProps {
   children?: React.ReactNode[] | React.ReactNode;
+  onClick?: (e: React.MouseEvent) => void;
   onClose?: React.MouseEventHandler<HTMLButtonElement>;
   closeButtonAriaLabel?: string;
   theme?: {


### PR DESCRIPTION
## Description

Adding `onClick` in the `<Card />` type to avoid Typescript error when use it.

This PR sort out issue #220 

## Setup

1. create a new folder _quantum_ in _node_modules/@catho in the your Typescript (TS) project
2. in Quantum's project, run `yarn run build`
3. copy folder _dist_ to project path (ex.: `cp -r dist/ ~/projects/new-register-candidate_app/node_modules/@catho/quantum/

## Review guide

Adding in your TS project this:

```
<Card onClick={(e): void => console.log('foo and bar', e)}>
	<Card.Content>
      Duis ac enim non leo dapibus placerat ut vel ligula. Pellentesque sed
      metus elit. In hac habitasse platea dictumst. Fusce non purus a dui
      semper molestie vitae in sapien. In a odio quis nisi placerat varius
      eget et magna. Donec nec cursus mauris. Donec a cursus velit.
    </Card.Content>
</Card>
```

- [x] should not see TS error about `onClick` props
