### PR TITLE
fix(Avatar): Fixes export default

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -29,6 +29,7 @@ import Pagination from './Pagination';
 import Hamburger from './Hamburger';
 import Socials from './Socials';
 import SocialButton from './SocialButton';
+import Avatar from './Avatar';
 
 export {
   Accordion,
@@ -69,4 +70,5 @@ export {
   Hamburger,
   Socials,
   SocialButton,
+  Avatar,
 };


### PR DESCRIPTION
## Description
This PR fixes to component should be imported this way `import { Avatar } from '@catho/quantum'` or this way `import Avatar from '@catho/quantum/Avatar'`

## The problem
The individual export of component is missing.

when imports `import { Avatar } from '@catho/quantum'`, this error was shown:
![image](https://user-images.githubusercontent.com/3389749/96036107-675d6c80-0e3a-11eb-8e3d-05ccd5a452d8.png)

The component only imports this way `import Avatar from '@catho/quantum/Avatar';`

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
