### PR TITLE
fix(Input): update state when value prop is changed

### DIFF
--- a/components/Input/Input.jsx
+++ b/components/Input/Input.jsx
@@ -96,6 +96,15 @@ class Input extends React.Component {
     this._id = id || ID_GENERATOR.next().value;
   }
 
+  componentDidUpdate = () => {
+    const { currentValue } = this.state;
+    const { value } = this.props;
+
+    if (currentValue !== value) {
+      this.setState({ currentValue: value });
+    }
+  };
+
   onChangeInput = ev => {
     const { onChange } = this.props;
     const inputValue = ev.currentTarget.value;

--- a/components/Input/Input.unit.test.jsx
+++ b/components/Input/Input.unit.test.jsx
@@ -113,6 +113,14 @@ describe('Input component', () => {
     expect(onCleanMock).toHaveBeenCalled();
   });
 
+  it('should update state when value property is changed', () => {
+    const component = mount(<Input value="foo" />);
+    expect(component.state('currentValue')).toBe('foo');
+
+    component.setProps({ value: 'bar' }).update();
+    expect(component.state('currentValue')).toBe('bar');
+  });
+
   describe('with a label', () => {
     it('should match label "htmlFor" label param with "id" input param', () => {
       const id = 'input-id';


### PR DESCRIPTION
## Description
This PR fixes the problem of **updating the Input text** when a new string is defined in the `value` property after the first render.
**Related issue: #245**

## Setup
to view the component's behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation