### PR TITLE
fix(Avatar): updates svg pointer-events

### DIFF
--- a/components/Avatar/Avatar.jsx
+++ b/components/Avatar/Avatar.jsx
@@ -23,6 +23,7 @@ const AvatarImage = styled.img.attrs({
   width: 24px;
   height: 24px;
   overflow: hidden;
+  pointer-events: none;
 `;
 
 const AvatarIcon = styled(Person).attrs({
@@ -34,6 +35,7 @@ const AvatarIcon = styled(Person).attrs({
   ${borderStyle}
   background: ${colors.neutral[700]};
   padding: 3px;
+  pointer-events: none;
 `;
 
 const AvatarNotification = styled.span`
@@ -49,6 +51,11 @@ const AvatarNotification = styled.span`
 const AvatarText = styled.span`
   display: inline-flex;
   margin-left: 12px;
+  pointer-events: none;
+`;
+
+const IconToggle = styled(Icon)`
+  pointer-events: none;
 `;
 
 /** This components is used to display the user picture. */
@@ -64,7 +71,7 @@ const Avatar = ({
     {picture ? <AvatarImage src={picture} /> : <AvatarIcon />}
     {hasNotification && <AvatarNotification />}
     {text && <AvatarText>{text}</AvatarText>}
-    {hasToggle && <Icon name="keyboard_arrow_down" />}
+    {hasToggle && <IconToggle name="keyboard_arrow_down" />}
   </AvatarWrapper>
 );
 

--- a/components/Avatar/__snapshots__/Avatar.unit.test.jsx.snap
+++ b/components/Avatar/__snapshots__/Avatar.unit.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`<Avatar /> Should match snapshot With href 1`] = `
   border-radius: 50%;
   background: #424242;
   padding: 3px;
+  pointer-events: none;
 }
 
 <a
@@ -61,6 +62,7 @@ exports[`<Avatar /> Should match snapshot With notification 1`] = `
   border-radius: 50%;
   background: #424242;
   padding: 3px;
+  pointer-events: none;
 }
 
 .c2 {
@@ -118,6 +120,7 @@ exports[`<Avatar /> Should match snapshot With picture 1`] = `
   width: 24px;
   height: 24px;
   overflow: hidden;
+  pointer-events: none;
 }
 
 <span
@@ -149,6 +152,7 @@ exports[`<Avatar /> Should match snapshot With text 1`] = `
   border-radius: 50%;
   background: #424242;
   padding: 3px;
+  pointer-events: none;
 }
 
 .c2 {
@@ -157,6 +161,7 @@ exports[`<Avatar /> Should match snapshot With text 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   margin-left: 12px;
+  pointer-events: none;
 }
 
 <span
@@ -204,6 +209,11 @@ exports[`<Avatar /> Should match snapshot With toggle icon 1`] = `
   border-radius: 50%;
   background: #424242;
   padding: 3px;
+  pointer-events: none;
+}
+
+.c2 {
+  pointer-events: none;
 }
 
 <span
@@ -229,7 +239,7 @@ exports[`<Avatar /> Should match snapshot With toggle icon 1`] = `
   
   <svg
     aria-hidden="true"
-    className="MuiSvgIcon-root"
+    className="MuiSvgIcon-root c2"
     data-qtm-preloader="icon"
     focusable="false"
     role="presentation"
@@ -266,6 +276,7 @@ exports[`<Avatar /> Should match snapshot Without picture 1`] = `
   border-radius: 50%;
   background: #424242;
   padding: 3px;
+  pointer-events: none;
 }
 
 <span


### PR DESCRIPTION
## Description
The Avatar component, in some cases, need to be clicked as trigger to open menu options.
For this cases, the svg icons needs a `pointer-events: none` to the mouse click works right.
Without it,  the click field gets harmed. 

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation