### PR TITLE
ci(deploy to gh pages): removes gh_token to use only github_token

### DIFF
--- a/.github/workflows/actions-publish.yml
+++ b/.github/workflows/actions-publish.yml
@@ -61,5 +61,4 @@ jobs:
       - name: Deploy storybook to Github Pages
         run: yarn deploy-storybook -- --ci
         env:
-          GH_TOKEN: catho:${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/stories/Avatar/Avatar.story.jsx
+++ b/stories/Avatar/Avatar.story.jsx
@@ -70,7 +70,7 @@ const TabExample = (
   </Tab>
 );
 
-const description = `Avatar components are used for showing a thumbnail of the user picture or an user icon if the picture is done defined, also it can display a dot to alert that there is some notification.`;
+const description = `Avatars are used for showing a thumbnail of the user picture or an user icon if the picture is done defined, also it can display a dot to alert that there is some notification.`;
 
 storiesOf('Avatar', module).add('Avatar', () => (
   <AutoExample


### PR DESCRIPTION
## Description
Put the description of the task here.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation