### PR TITLE
ci(deploy ghpages): removes github_token and keep only gh_token

### DIFF
--- a/.github/workflows/actions-publish.yml
+++ b/.github/workflows/actions-publish.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Deploy storybook to Github Pages
         run: yarn deploy-storybook -- --ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Put the description of the task here.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] IE 11
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation