### PR TITLE
fix(Stepper component): fixes min-width for desktop

### DIFF
--- a/components/Stepper/__snapshots__/Stepper.unit.test.jsx.snap
+++ b/components/Stepper/__snapshots__/Stepper.unit.test.jsx.snap
@@ -64,6 +64,12 @@ exports[`<Stepper /> should match snapshots 1`] = `
 }
 
 @media (min-width:1024px) {
+  .c0 {
+    min-width: auto;
+  }
+}
+
+@media (min-width:1024px) {
   .c1 {
     width: 72px;
     height: 72px;
@@ -678,6 +684,16 @@ exports[`<Stepper /> should match snapshots 2`] = `
 .c5 {
   display: block;
   font-size: 14px;
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    min-width: auto;
+  }
 }
 
 @media (min-width:1024px) {
@@ -1298,6 +1314,20 @@ exports[`<Stepper /> should match snapshots 3`] = `
 }
 
 @media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    min-width: auto;
+  }
+}
+
+@media (min-width:1024px) {
   .c1 {
     width: 72px;
     height: 72px;
@@ -1912,6 +1942,24 @@ exports[`<Stepper /> should match snapshots 4`] = `
 .c5 {
   display: block;
   font-size: 14px;
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    min-width: auto;
+  }
 }
 
 @media (min-width:1024px) {
@@ -2532,6 +2580,28 @@ exports[`<Stepper /> should match snapshots 5`] = `
 }
 
 @media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    min-width: auto;
+  }
+}
+
+@media (min-width:1024px) {
   .c1 {
     width: 72px;
     height: 72px;
@@ -3146,6 +3216,32 @@ exports[`<Stepper /> should match snapshots 6`] = `
 .c5 {
   display: block;
   font-size: 14px;
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    min-width: auto;
+  }
 }
 
 @media (min-width:1024px) {

--- a/components/Stepper/style.js
+++ b/components/Stepper/style.js
@@ -17,6 +17,10 @@ const Wrapper = styled.div`
   align-items: center;
   min-width: 300px;
 
+  ${desktopBreakpoint`
+    min-width: auto;
+  `}
+
   .progress {
     background-image: ${({
       degrees: { 0: reference, 1: position },


### PR DESCRIPTION
## Description
Fixes the min width in desktop.

![image](https://user-images.githubusercontent.com/3389749/108259360-c3fdca80-713f-11eb-82f4-53821e67dc6c.png)


## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation