### PR TITLE
fix(Tags component): updates proptypes to receive elements instead only strings

### DIFF
--- a/components/Tag/Tag.jsx
+++ b/components/Tag/Tag.jsx
@@ -127,7 +127,10 @@ const Tag = ({ children, text, onClose, ...rest }) => (
 
 Tag.propTypes = {
   bold: PropTypes.bool,
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   inverted: PropTypes.bool,
   /** A callback that is called when close button is clicked */
   onClose: PropTypes.func,

--- a/components/Tag/Tag.jsx
+++ b/components/Tag/Tag.jsx
@@ -127,7 +127,7 @@ const Tag = ({ children, text, onClose, ...rest }) => (
 
 Tag.propTypes = {
   bold: PropTypes.bool,
-  children: PropTypes.string,
+  children: PropTypes.node,
   inverted: PropTypes.bool,
   /** A callback that is called when close button is clicked */
   onClose: PropTypes.func,

--- a/components/Tag/index.d.ts
+++ b/components/Tag/index.d.ts
@@ -3,7 +3,7 @@ import React from 'react';
 export interface TagProps {
     bold?: boolean;
     inverted?: boolean;
-    children?: React.ReactNode;
+    children?: React.ReactNode[] | React.ReactNode;
     onClose?: React.MouseEventHandler<HTMLButtonElement>;
     size?: 'small' | 'medium' | 'large';
     skin?: 'neutral' | 'primary' | 'success' | 'warning' | 'error';

--- a/components/Tag/index.d.ts
+++ b/components/Tag/index.d.ts
@@ -3,6 +3,7 @@ import React from 'react';
 export interface TagProps {
     bold?: boolean;
     inverted?: boolean;
+    children?: React.ReactNode;
     onClose?: React.MouseEventHandler<HTMLButtonElement>;
     size?: 'small' | 'medium' | 'large';
     skin?: 'neutral' | 'primary' | 'success' | 'warning' | 'error';


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-262
Today, the component only checks if the prop is a string. This PR updates to receive a html element either.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
- [ ] In the file Tag.story.jsx, updates one example of Tag to receive html element instead string and see if proptypes warn;
- [X] TypeScript updated
