### PR TITLE
fix(Carousel component): fixes watch media mock in jest

### DIFF
--- a/components/Carousel/Carousel.unit.test.jsx
+++ b/components/Carousel/Carousel.unit.test.jsx
@@ -1,3 +1,4 @@
+import './watchMedia.mock';
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';

--- a/components/Carousel/watchMedia.mock
+++ b/components/Carousel/watchMedia.mock
@@ -1,0 +1,7 @@
+window.matchMedia = jest.fn().mockImplementation(query => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+}));

--- a/jest-config.js
+++ b/jest-config.js
@@ -3,16 +3,3 @@ import Adapter from 'enzyme-adapter-react-16';
 import 'jest-styled-components';
 
 Enzyme.configure({ adapter: new Adapter() });
-
-if (typeof window !== 'undefined') {
-  // eslint-disable-next-line func-names
-  window.matchMedia =
-    window.matchMedia ||
-    function() {
-      return {
-        matches: false,
-        addListener() {},
-        removeListener() {},
-      };
-    };
-}


### PR DESCRIPTION
## Description
because the import of react-slick in carousel component, jest needs to watchMedia to monitoring it.

Error: 
![image](https://user-images.githubusercontent.com/3389749/115264743-f52d5380-a10c-11eb-843a-b0712e9fd38c.png)

This erros was fixed adding this code in jest-config:
```
if (typeof window !== 'undefined') {
  // eslint-disable-next-line func-names
  window.matchMedia =
    window.matchMedia ||
    function() {
      return {
        matches: false,
        addListener() {},
        removeListener() {},
      };
    };
}

```
But with this, who implements Quantum, this error will show, because its application doesnt have this code in your jest-config file.

To fix this issue, i import this code only in carousel unit test, with this, this code will be exported even with babel transpilling.
there being no need to implement this code in applications.

**sorry for many codes word in description**
## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Code review