### PR TITLE
fix(Typescript compatibility): updates ts props in components

### DIFF
--- a/components/Dropdown/index.d.ts
+++ b/components/Dropdown/index.d.ts
@@ -10,6 +10,7 @@ export interface DropdownProps {
   ignoreSpecialChars?: boolean;
   error?: string;
   id?: string;
+  name?: string;
   label?: string;
   placeholder?: string;
   selectedItem?: ItemPropType;

--- a/components/Form/index.d.ts
+++ b/components/Form/index.d.ts
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { FormHTMLAttributes } from 'react';
 
-export interface FormProps {
+export interface FormProps extends FormHTMLAttributes<HTMLFormElement> {
     children: React.ReactNode[] | React.ReactNode;
     onSubmit?: ({ valid }?: { valid: boolean }) => void;
     onValidSubmit?: (values?: { [name: string]: string | undefined }) => void;


### PR DESCRIPTION
## Description
- Dropdown:
the ts props of component has missing `name` prop.
![image](https://user-images.githubusercontent.com/3389749/117168795-ded6f700-ad9e-11eb-9c34-57d150234547.png)

- Form
Some implementers having problems when uses native form attributes in component.

## Setup
to view the components behavior, run `yarn storybook`

- [ ] Code review