### PR TITLE
fix(CCOM-89-Accordion): Fixing clickable area for links

### DIFF
--- a/components/Accordion/Accordion.jsx
+++ b/components/Accordion/Accordion.jsx
@@ -78,6 +78,8 @@ const AccordionContent = styled.div`
       color: ${primary[700]};
       font-size: ${baseFontSize - 2}px;
       text-decoration: underline;
+      display: block;
+      padding: ${xsmall}px 0;
 
       &:hover {
         color: ${secondary[700]};
@@ -87,10 +89,6 @@ const AccordionContent = styled.div`
     ul {
       list-style-type: none;
       padding: 0;
-      
-      & > li {
-        padding: ${xsmall}px 0;
-      }
     }
 
     p {

--- a/components/Accordion/__snapshots__/Accordion.unit.test.jsx.snap
+++ b/components/Accordion/__snapshots__/Accordion.unit.test.jsx.snap
@@ -49,6 +49,8 @@ exports[`Accordion component Should match the snapshot 1`] = `
   font-size: 14px;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  display: block;
+  padding: 8px 0;
 }
 
 .c5 a:hover {
@@ -58,10 +60,6 @@ exports[`Accordion component Should match the snapshot 1`] = `
 .c5 ul {
   list-style-type: none;
   padding: 0;
-}
-
-.c5 ul > li {
-  padding: 8px 0;
 }
 
 .c5 p {


### PR DESCRIPTION
## Description
Fixing clickable area in links due to Accordion being used in the footer
https://jirasoftware.catho.com.br/browse/CCOM-89

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
- [ ] TypeScript updated
- [ ] a11y

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation