### PR TITLE
fix(dependencies): Change range of react version on peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,8 +128,8 @@
     "storybook": "^6.3.4"
   },
   "peerDependencies": {
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
+    "react": "^16.7.0 || ^17",
+    "react-dom": "^16.7.0 || ^17",
     "styled-components": ">= 4"
   },
   "lint-staged": {


### PR DESCRIPTION
## Description
Change range of react version on peer dependencies

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review