### PR TITLE
fix(icon): Includes person_circle icon on TS definitions

### DIFF
--- a/components/Icon/index.d.ts
+++ b/components/Icon/index.d.ts
@@ -605,6 +605,7 @@ export type IconNames =
     | 'perm_phone_msg'
     | 'perm_scan_wifi'
     | 'person_add'
+    | 'person_circle'
     | 'personal_video'
     | 'person'
     | 'person_outline'


### PR DESCRIPTION
## Description
Includes person_circle icon on TS definitions

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
- [ ] TypeScript updated