### PR TITLE
fix(UseMaxWidthMediaQuery): Implementing support to safari and adding mock to jest config 

### DIFF
--- a/components/shared/helpers.js
+++ b/components/shared/helpers.js
@@ -1,0 +1,16 @@
+const matchMediaMock = (match = false) =>
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: match,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+
+export { matchMediaMock as default };

--- a/components/shared/hooks/UseMaxWidthMediaQuery/useMaxWidthMediaQuery.jsx
+++ b/components/shared/hooks/UseMaxWidthMediaQuery/useMaxWidthMediaQuery.jsx
@@ -17,6 +17,7 @@ const useMaxWidthMediaQuery = width => {
     try {
       media.addEventListener('change', e => updateTarget(e));
     } catch (e1) {
+      /* istanbul ignore next */
       try {
         media.addListener(e => updateTarget(e));
       } catch (e2) {
@@ -32,6 +33,7 @@ const useMaxWidthMediaQuery = width => {
       try {
         media.removeEventListener('change', e => updateTarget(e));
       } catch (e3) {
+        /* istanbul ignore next */
         media.removeListener(updateTarget);
       }
     };

--- a/components/shared/hooks/UseMaxWidthMediaQuery/useMaxWidthMediaQuery.jsx
+++ b/components/shared/hooks/UseMaxWidthMediaQuery/useMaxWidthMediaQuery.jsx
@@ -13,13 +13,28 @@ const useMaxWidthMediaQuery = width => {
 
   useEffect(() => {
     const media = window.matchMedia(`(max-width: ${width}px)`);
-    media.addEventListener('change', e => updateTarget(e));
+
+    try {
+      media.addEventListener('change', e => updateTarget(e));
+    } catch (e1) {
+      try {
+        media.addListener(e => updateTarget(e));
+      } catch (e2) {
+        console.error(e2);
+      }
+    }
 
     if (media.matches) {
       setTargetReached(true);
     }
 
-    return () => media.removeEventListener('change', e => updateTarget(e));
+    return () => {
+      try {
+        media.removeEventListener('change', e => updateTarget(e));
+      } catch (e3) {
+        media.removeListener(updateTarget);
+      }
+    };
   }, []);
 
   return targetReached;

--- a/components/shared/hooks/UseMaxWidthMediaQuery/useMaxWidthMediaQuery.unit.test.jsx
+++ b/components/shared/hooks/UseMaxWidthMediaQuery/useMaxWidthMediaQuery.unit.test.jsx
@@ -1,26 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import matchMediaMock from '../../helpers';
 
 import ExampleMediaQuery from './Example';
 
-const matchMediaMock = (match = false) =>
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: jest.fn().mockImplementation(query => ({
-      matches: match,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(),
-      removeListener: jest.fn(),
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    })),
-  });
-
 describe('useMaxWidthMediaQuery', () => {
   it('should be bigger than 768px', () => {
-    matchMediaMock();
     const component = mount(<ExampleMediaQuery />);
     expect(component.find('h1').text()).toBe('More than 768');
   });

--- a/jest-config.js
+++ b/jest-config.js
@@ -2,7 +2,9 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import 'jest-styled-components';
 import '@testing-library/jest-dom';
-
 import 'snapshot-diff/extend-expect';
 
+import matchMediaMock from './components/shared/helpers';
+
 Enzyme.configure({ adapter: new Adapter() });
+matchMediaMock();

--- a/stories/Hooks/Examples/UseMaxWidthMediaQueryExample.jsx
+++ b/stories/Hooks/Examples/UseMaxWidthMediaQueryExample.jsx
@@ -5,6 +5,8 @@ import {
   SimpleHighlight,
 } from '@catho/quantum-storybook-ui';
 
+import Alert from '../../../components/Alert';
+
 const importMediaQuery = `import useMaxWidthMediaQuery from '@catho/quantum/shared/hooks'`;
 
 const mediaQueryCode = `
@@ -34,10 +36,35 @@ const Component = () => {
 export default Component;
 `;
 
+const mockImport = `
+import matchMediaMock from '@catho/quantum/shared/helpers'
+
+describe('My tests', () => {
+  beforeAll(() => {
+    matchMediaMock()
+  });
+});
+`;
+
 const UseMaxWidthMediaQueryExample = () => (
   <StoryContainer>
     <Title as="h2">Importing</Title>
     <SimpleHighlight>{importMediaQuery}</SimpleHighlight>
+
+    <br />
+    <Alert icon="warning" skin="warning">
+      <strong>Important:</strong>
+      <p>
+        Due to jest{' '}
+        <a href="https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom">
+          not supporting windows.matchMedia yet
+        </a>
+        , we recommend that you use the below mock in your tests. Just add this
+        function to the jest-config file or inside a before all in the
+        component&apos;s test file.
+        <SimpleHighlight>{mockImport}</SimpleHighlight>
+      </p>
+    </Alert>
 
     <Title as="h3">Usage</Title>
     <p>


### PR DESCRIPTION
## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile