### PR TITLE
fix(Social Button): rollback on a change due to quantum ui auto example error

### DIFF
--- a/components/SocialButton/SocialButton.jsx
+++ b/components/SocialButton/SocialButton.jsx
@@ -29,20 +29,22 @@ const FacebookButton = styled(BaseButton)`
 `;
 
 const SocialButton = ({ provider, ...props }) => {
-  const providers = {
-    facebook: (
-      <FacebookButton {...props}>
-        <FacebookIcon title="facebook-button" size="24" />
-      </FacebookButton>
-    ),
-    google: (
-      <GoogleButton {...props} stroked skin="neutral">
-        <GoogleIcon title="google-button" size="24" />
-      </GoogleButton>
-    ),
-  };
-
-  return providers[provider];
+  switch (provider) {
+    case 'facebook':
+      return (
+        <FacebookButton {...props}>
+          <FacebookIcon title="facebook-button" size="24" />
+        </FacebookButton>
+      );
+    case 'google':
+      return (
+        <GoogleButton {...props} stroked skin="neutral">
+          <GoogleIcon title="google-button" size="24" />
+        </GoogleButton>
+      );
+    default:
+      return <Button />;
+  }
 };
 
 SocialButton.propTypes = {


### PR DESCRIPTION
## Description
Rolling back a change made [here](https://github.com/catho/quantum/pull/380) due to error in the quantum ui auto example 
![Captura de tela de 2022-02-17 18-12-06](https://user-images.githubusercontent.com/85566581/154573269-624b2635-b555-4428-ad54-0285b7871726.png)

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation