### PR TITLE
fix(Stepper): corrige resolução do componente em 1024+

### DIFF
--- a/components/Stepper/__snapshots__/Stepper.unit.test.jsx.snap
+++ b/components/Stepper/__snapshots__/Stepper.unit.test.jsx.snap
@@ -24,6 +24,9 @@ exports[`<Stepper /> should match snapshots 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
   font-weight: 700;
   width: 64px;
   height: 64px;
@@ -164,6 +167,9 @@ exports[`<Stepper /> should match snapshots 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
   font-weight: 700;
   width: 64px;
   height: 64px;
@@ -308,6 +314,9 @@ exports[`<Stepper /> should match snapshots 3`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
   font-weight: 700;
   width: 64px;
   height: 64px;
@@ -456,6 +465,9 @@ exports[`<Stepper /> should match snapshots 4`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
   font-weight: 700;
   width: 64px;
   height: 64px;
@@ -608,6 +620,9 @@ exports[`<Stepper /> should match snapshots 5`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
   font-weight: 700;
   width: 64px;
   height: 64px;
@@ -764,6 +779,9 @@ exports[`<Stepper /> should match snapshots 6`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
   font-weight: 700;
   width: 64px;
   height: 64px;

--- a/components/Stepper/style.js
+++ b/components/Stepper/style.js
@@ -40,6 +40,7 @@ const Wrapper = styled.div`
 const RadialProgressBar = styled.div`
   border-radius: 50%;
   display: flex;
+  flex: none;
   font-weight: 700;
 
   width: ${MOBILE_CIRCLE_SIZE}px;


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-346

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
- [ ] TypeScript updated

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation