### PR TITLE
fix(TextArea): fixes the current update state

### DIFF
--- a/components/TextArea/TextArea.jsx
+++ b/components/TextArea/TextArea.jsx
@@ -60,6 +60,16 @@ class TextArea extends Component {
     this._linHeight = 1.5;
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { currentValue } = this.state;
+    const { value } = this.props;
+
+    if (currentValue !== value && prevProps.value !== value) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ ...prevState, currentValue: value });
+    }
+  }
+
   onChangeTextArea = event => {
     const { target } = event;
     const { onChange } = this.props;

--- a/components/TextArea/TextArea.unit.test.jsx
+++ b/components/TextArea/TextArea.unit.test.jsx
@@ -93,4 +93,13 @@ describe('TextArea component', () => {
       expect(textArea.getAttribute('id')).toEqual(label.getAttribute('for'));
     });
   });
+
+  it('should update state when value property is changed', () => {
+    const { rerender } = render(<TextArea label="Text label" value="foo" />);
+    const componentInput = screen.getByRole('textbox', /Text label/i);
+    expect(componentInput.value).toEqual('foo');
+
+    rerender(<TextArea label="Text label" value="bar" />);
+    expect(componentInput.value).toEqual('bar');
+  });
 });


### PR DESCRIPTION
## Description
Same was done with Input (https://github.com/catho/quantum/pull/369).
Now in Textarea component too.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review