### PR TITLE
fix(QTM-351): Adjusts on handle click outside

### DIFF
--- a/components/AutoComplete/AutoComplete.jsx
+++ b/components/AutoComplete/AutoComplete.jsx
@@ -195,9 +195,8 @@ const AutoComplete = ({
     handleFilter(value);
   };
 
-  /* istanbul ignore next */
   const handleClickOutside = event => {
-    if (!wrapperRef.current.contains(event.target)) {
+    if (!wrapperRef.current?.contains(event.target)) {
       setShowSuggestions(false);
     }
   };
@@ -220,11 +219,11 @@ const AutoComplete = ({
     setCursor(0);
   };
 
-  /* istanbul ignore next */
   const handleEscPress = ({ key }) => {
-    if (key === EscapeKeyPressValue) {
+    const node = wrapperRef.current;
+    if (node && key === EscapeKeyPressValue) {
       setShowSuggestions(false);
-      wrapperRef.current.children[1].focus();
+      node.children[1].focus();
       setCursor(0);
     }
   };


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-351

https://watch.screencastify.com/v/4jtLRBnBCfV7N0jBzHOq

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review