### PR TITLE
fix(link): handles forward reffereing on component

### DIFF
--- a/components/Link/Link.jsx
+++ b/components/Link/Link.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 import { colors } from '../shared/theme';
 
@@ -22,11 +23,11 @@ const StyledLink = styled.a`
   `}
 `;
 
-const Link = ({ children, skin, underline, ...rest }) => (
-  <StyledLink skin={skin} underline={underline} {...rest}>
+const Link = forwardRef(({ children, skin, underline, ...rest }, ref) => (
+  <StyledLink ref={ref} skin={skin} underline={underline} {...rest}>
     {children}
   </StyledLink>
-);
+));
 
 Link.propTypes = {
   theme: PropTypes.shape({


### PR DESCRIPTION
## Description
Handles link component to support `useRef` on native element

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review