### PR TITLE
feat(QTM-468): Added property to set an initial value for autocomplete

### DIFF
--- a/components/AutoComplete/AutoComplete.jsx
+++ b/components/AutoComplete/AutoComplete.jsx
@@ -146,6 +146,7 @@ const AutoComplete = ({
   id,
   name,
   label,
+  value,
   error,
   disabled,
   helperText,
@@ -157,7 +158,7 @@ const AutoComplete = ({
   required,
   skin,
 }) => {
-  const [userTypedValue, setUserTypedValue] = useState('');
+  const [userTypedValue, setUserTypedValue] = useState(value);
   const [filterSuggestions, setFilterSuggestions] = useState(suggestions);
   const [filterSuggestionsLength, setFilterSuggestionsLength] = useState(
     filterSuggestions.length,
@@ -174,24 +175,24 @@ const AutoComplete = ({
   } 
   ${cursor + 1} de ${filterSuggestionsLength} está destacado`;
 
-  const filterItems = value =>
+  const filterItems = currentValue =>
     suggestions.filter(suggestion => {
       let option = normalizeChars(suggestion.toLowerCase());
       option = normalizeChars(option);
-      return option.indexOf(normalizeChars(value.toLowerCase())) > -1;
+      return option.indexOf(normalizeChars(currentValue.toLowerCase())) > -1;
     });
 
-  const handleFilter = value => {
-    const filteredValues = filterItems(value);
+  const handleFilter = currentValue => {
+    const filteredValues = filterItems(currentValue);
     setShowSuggestions(!!filteredValues.length);
     setFilterSuggestions(filteredValues);
   };
 
-  const handleChange = value => {
-    setUserTypedValue(value);
-    onChange(value);
+  const handleChange = currentValue => {
+    setUserTypedValue(currentValue);
+    onChange(currentValue);
     setCursor(0);
-    handleFilter(value);
+    handleFilter(currentValue);
   };
 
   const handleClickOutside = event => {
@@ -393,6 +394,7 @@ AutoComplete.propTypes = {
   disabled: PropTypes.bool,
   /** Displays a label text that describes the field */
   label: PropTypes.string,
+  value: PropTypes.string,
   name: PropTypes.string,
   placeholder: PropTypes.string,
   /** Callback function to receive what the user is typing */
@@ -413,6 +415,7 @@ AutoComplete.defaultProps = {
   id: '',
   name: '',
   label: '',
+  value: '',
   helperText: '',
   error: '',
   disabled: false,

--- a/components/AutoComplete/AutoComplete.unit.test.jsx
+++ b/components/AutoComplete/AutoComplete.unit.test.jsx
@@ -198,4 +198,11 @@ describe('AutoComplete', () => {
       screen.getByRole('option', { name: 'melancia' }),
     ).toBeInTheDocument();
   });
+
+  it('Should have a value when prop value is set', () => {
+    const initialValue = 'initial value';
+    render(<AutoComplete value={initialValue} suggestions={[]} />);
+    const autoCompleteInput = screen.getByRole('combobox');
+    expect(autoCompleteInput).toHaveAttribute('value', initialValue);
+  });
 });

--- a/components/AutoComplete/index.d.ts
+++ b/components/AutoComplete/index.d.ts
@@ -9,6 +9,7 @@ export interface AutoCompleteProps {
   id?: string;
   name?: string;
   label?: string;
+  value?: string;
   helperText?: string;
   error?: string;
   disabled?: boolean;


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-468

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Code review
- [ ] TypeScript updated

## Change Validation Guide

- In quantum, run `yarn` & `yarn build`
- Clone repo https://github.com/catho/recruiter-experience_company-registration_app/tree/development
- Add an .env file in the root of the repository with the data provided in the task in Jira
- Run `yarn add ~/quantum/dist`, `yarn ` & `yarn dev`
- Add the value={values.role} attribute to the AutoComplete component on line 145 of the src/components/Forms/FormRegistrationData/index.tsx file
- On the application page in the browser, fill in all the data in the form in the first step and click on the "Continuar" button and then on "Voltar".
- Check if the "Cargo" field has preserved the previously entered value


