### PR TITLE
Refactor uniqId generator to improve performance and remove babel-polyfill dependency

### DIFF
--- a/components/Checkbox/CheckboxButton.jsx
+++ b/components/Checkbox/CheckboxButton.jsx
@@ -2,12 +2,12 @@ import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import HiddenInput from '../shared/HiddenInput';
-import uniqId from '../shared/uniqId';
+import { createUniqId } from '../shared/uniqId';
 import Icon from '../Icon';
 import Button from '../Button';
 import CheckboxGroupContext from './CheckboxGroupContext';
 
-const ID_GENERATOR = uniqId('checkbox-button-');
+const uniqId = createUniqId('checkbox-button-');
 
 const HiddenCheckbox = styled(HiddenInput).attrs({
   type: 'checkbox',
@@ -63,7 +63,7 @@ const CheckboxButton = ({
     inline,
     size,
   } = useContext(CheckboxGroupContext);
-  const [_id] = useState(id || ID_GENERATOR.next().value);
+  const [_id] = useState(id || uniqId());
 
   let checkSkin;
 

--- a/components/Dropdown/Dropdown.jsx
+++ b/components/Dropdown/Dropdown.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import Downshift from 'downshift';
 import Icon from '../Icon/Icon';
-import { FieldGroup, shadow, uniqId, normalizeChars } from '../shared';
+import { FieldGroup, shadow, createUniqId, normalizeChars } from '../shared';
 import { colors, spacing, baseFontSize } from '../shared/theme';
 
 import {
@@ -14,7 +14,7 @@ import {
   HelperText,
 } from '../Input/sub-components';
 
-const ID_GENERATOR = uniqId('dropdown-');
+const uniqId = createUniqId('dropdown-');
 const ITEM_HEIGHT = '44px';
 const MAX_ITEMS_VISIBILITY = 7;
 const DROPITEM_FONT_SIZE = baseFontSize * 0.875;
@@ -268,7 +268,7 @@ const Dropdown = ({
 
   const hasLabel = !!label;
 
-  const [_id] = useState(id || ID_GENERATOR.next().value);
+  const [_id] = useState(id || uniqId());
 
   const inputFilter = value =>
     items.filter(item => {

--- a/components/Input/Input.jsx
+++ b/components/Input/Input.jsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 
 import MaskedInput from 'react-text-mask';
 
-import { FieldGroup, uniqId } from '../shared';
+import { FieldGroup, createUniqId } from '../shared';
 import Icon from '../Icon';
 // eslint-disable-next-line import/no-cycle
 import InputTypes from './InputTypes';
@@ -17,7 +17,7 @@ import {
 } from './sub-components';
 import { spacing, colors, baseFontSize } from '../shared/theme';
 
-const ID_GENERATOR = uniqId('input-');
+const uniqId = createUniqId('input-');
 
 const InputIcon = styled(Icon)`
   cursor: pointer;
@@ -90,7 +90,7 @@ class Input extends Component {
       hasDefaultValue: value !== null && value[0],
     };
 
-    this._id = id || ID_GENERATOR.next().value;
+    this._id = id || uniqId();
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/components/Pagination/sub-components/Desktop.jsx
+++ b/components/Pagination/sub-components/Desktop.jsx
@@ -4,9 +4,9 @@ import ActionButton from './ActionButton';
 import Dots from './Dots';
 import PageButton from './PageButton';
 import pagination from '../utils/pagination';
-import uniqId from '../../shared/uniqId';
+import { createUniqId } from '../../shared/uniqId';
 
-const DOT_KEY_GENERATOR = uniqId('dot-');
+const uniqId = createUniqId('dot-');
 
 const Desktop = ({
   activePage,
@@ -34,7 +34,7 @@ const Desktop = ({
 
     {pagination({ totalPages, activePage, hideLastPagination }).map(page => {
       if (page === '...') {
-        return <Dots key={DOT_KEY_GENERATOR.next().value} />;
+        return <Dots key={uniqId()} />;
       }
 
       return (

--- a/components/RadioGroup/RadioButton.jsx
+++ b/components/RadioGroup/RadioButton.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import Button from '../Button';
 import HiddenInput from '../shared/HiddenInput';
 import Icon from '../Icon';
-import uniqId from '../shared/uniqId';
+import { createUniqId } from '../shared/uniqId';
 import {
   colors,
   spacing,
@@ -12,7 +12,7 @@ import {
   baseFontSize as defaultBaseFontSize,
 } from '../shared/theme';
 
-const ID_GENERATOR = uniqId('radio-button-');
+const uniqId = createUniqId('radio-button-');
 
 const LockIcon = styled(Icon).attrs({
   name: 'lock',
@@ -78,7 +78,7 @@ class Radio extends Component {
 
     const { id } = props;
 
-    this._id = id || ID_GENERATOR.next().value;
+    this._id = id || uniqId();
   }
 
   render() {

--- a/components/SegmentedControl/SegmentedButton.jsx
+++ b/components/SegmentedControl/SegmentedButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Button from '../Button';
 import Icon from '../Icon';
 import HiddenInput from '../shared/HiddenInput';
-import uniqId from '../shared/uniqId';
+import { createUniqId } from '../shared/uniqId';
 
 const LabelButton = styled(Button).attrs({ forwardedAs: 'label' })`
   width: 100%;
@@ -18,7 +18,7 @@ const LabelButton = styled(Button).attrs({ forwardedAs: 'label' })`
 LabelButton.displayName = 'LabelButton';
 HiddenInput.displayName = 'HiddenInput';
 
-const ID_GENERATOR = uniqId('segmented-button-');
+const uniqId = createUniqId('segmented-button-');
 
 const a11yCheckedIndex = checked =>
   checked ? { tabIndex: -1, className: 'input-checked' } : { tabIndex: 0 };
@@ -32,7 +32,7 @@ const SegmentedButton = ({
   icon,
   darkMode,
 }) => {
-  const ID = ID_GENERATOR.next().value;
+  const ID = uniqId();
 
   const handleStroke = () => (darkMode ? checked : !checked);
 

--- a/components/SnackBar/SnackBar.jsx
+++ b/components/SnackBar/SnackBar.jsx
@@ -7,7 +7,7 @@ import { query } from '../Grid/sub-components/shared';
 import { hexToRgba, BREAKPOINTS } from '../shared';
 import Button from '../Button';
 import { Row, Col } from '../Grid';
-import uniqId from '../shared/uniqId';
+import { createUniqId } from '../shared/uniqId';
 import {
   components,
   spacing,
@@ -20,7 +20,7 @@ import { GetSkinIcon } from './IconTypes';
 
 const mediaQueries = query(BREAKPOINTS);
 
-const ID_GENERATOR = uniqId('snackbar-dialog-');
+const uniqId = createUniqId('snackbar-dialog-');
 
 const getBackgroundAndTextColorBySkin = ({
   skin,
@@ -197,7 +197,7 @@ class SnackBar extends Component {
     super(props);
     const { id } = props;
     this.snackBarSection = document.createElement('section');
-    this._id = id || ID_GENERATOR.next().value;
+    this._id = id || uniqId();
   }
 
   componentDidMount() {

--- a/components/TextArea/TextArea.jsx
+++ b/components/TextArea/TextArea.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { FieldGroup, uniqId } from '../shared';
+import { FieldGroup, createUniqId } from '../shared';
 import {
   InputLabel,
   InputErrorMessage,
@@ -11,7 +11,7 @@ import {
 } from '../Input/sub-components';
 import { spacing, colors, baseFontSize } from '../shared/theme';
 
-const ID_GENERATOR = uniqId('textarea-');
+const uniqId = createUniqId('textarea-');
 
 const CUSTOM_HEIGHT = 108;
 
@@ -37,7 +37,7 @@ const LINE_HEIGHT = 1.5;
 
 const TextArea = forwardRef((props, ref) => {
   const {
-    id = ID_GENERATOR.next().value,
+    id = uniqId(),
     value,
     onChange,
     label,

--- a/components/shared/index.js
+++ b/components/shared/index.js
@@ -5,12 +5,13 @@ import icons from './icons';
 import masks from './masks';
 import * as theme from './theme';
 import BREAKPOINTS from './breakpoints';
-import uniqId from './uniqId';
 import * as INPUT_STYLE from './inputStyle';
 import hexToRgba from './hexToRgba';
 import shadow from './shadow';
 import HiddenInput from './HiddenInput';
 import normalizeChars from './normalizeChars';
+
+export * from './uniqId';
 
 export {
   ErrorMessage,
@@ -21,7 +22,6 @@ export {
   theme,
   BREAKPOINTS,
   INPUT_STYLE,
-  uniqId,
   hexToRgba,
   shadow,
   HiddenInput,

--- a/components/shared/uniqId.js
+++ b/components/shared/uniqId.js
@@ -1,5 +1,3 @@
-import 'babel-polyfill';
-
 export default function*(prefix = '') {
   let _counter = -1;
   while (true) yield `${prefix}${(_counter += 1)}`;

--- a/components/shared/uniqId.js
+++ b/components/shared/uniqId.js
@@ -1,4 +1,9 @@
-export default function*(prefix = '') {
-  let _counter = -1;
-  while (true) yield `${prefix}${(_counter += 1)}`;
+export function createUniqId(prefix = '') {
+  let counter = -1;
+
+  return () => {
+    counter += 1;
+
+    return `${prefix}${counter}`;
+  };
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
   "dependencies": {
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^4.9.1",
-    "babel-polyfill": "^6.26.0",
     "datalist-polyfill": "^1.23.1",
     "downshift": "^3.1.10",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4847,15 +4847,6 @@ babel-plugin-transform-modern-regexp@^0.0.6:
   dependencies:
     regexp-tree "^0.0.85"
 
-babel-polyfill@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  integrity sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -6227,7 +6218,7 @@ core-js-pure@^3.23.3, core-js-pure@^3.25.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.1.tgz#653f4d7130c427820dcecd3168b594e8bb095a33"
   integrity sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
@@ -13926,11 +13917,6 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
-
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-  integrity sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
Closes #147 

This PR refactors the existing code that generates unique IDs to a new implementation using a closure. This refactor provides better performance and eliminates the need for the **babel-polyfill** dependency.