### PR TITLE
Remove unused libraries from the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "semantic-release": "19.0.5",
     "snapshot-diff": "^0.9.0",
     "storybook": "^6.5.13",
-    "strip-ansi": "^5.0.0",
     "styled-components": "5.3.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -110,11 +110,8 @@
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^4.9.1",
     "babel-polyfill": "^6.26.0",
-    "datalist-polyfill": "^1.23.1",
     "downshift": "^3.1.10",
     "prop-types": "^15.6.2",
-    "react-content-loader": "^3.4.2",
-    "react-image": "^1.5.1",
     "react-slick": "^0.28.0",
     "react-text-mask": "^5.4.3",
     "slugify": "^1.3.6"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "loki": "^0.24.0",
     "prettier": "^1.15.3",
     "react": "17.0.2",
-    "react-cookies": "^0.1.0",
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "17.0.2",
     "react-test-renderer": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6568,11 +6568,6 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-datalist-polyfill@^1.23.1:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/datalist-polyfill/-/datalist-polyfill-1.25.0.tgz#873152c7e41e96d16628ff81a532c8409cf8ebae"
-  integrity sha512-ZYdfZeUt9a4/CA0o2tpFOTHPDOBbjlYN0tUSxd96M/iFOidP8JdncNXQwnGZc0ThaCQ34tvEtrM7xPCgnWWZWA==
-
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -11251,7 +11246,7 @@ looks-same@^4.0.0:
     parse-color "^1.0.0"
     pngjs "^3.3.3"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -13320,14 +13315,6 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
-  dependencies:
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 prop-types@^15.0.0, prop-types@^15.5.6, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -13562,11 +13549,6 @@ rc@1.2.8, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-content-loader@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-3.4.2.tgz#187fbec2aa389635e4613faa046713f196173f40"
-  integrity sha512-UsL3uyPUBZbaPXr52E+MMIOjs7qr6QpcCiF9Xt7we0ACEMAFYp6rWNxVwJbk4/1Peqe9Deajs0PRW5ymvyF5SA==
-
 react-cookies@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/react-cookies/-/react-cookies-0.1.1.tgz#2a35807e04f5a13f58ccd1a9fb66574506873c88"
@@ -13621,14 +13603,6 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
-
-react-image@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/react-image/-/react-image-1.5.1.tgz#e900baa3f48b15ca94500542a2aff762c94431b8"
-  integrity sha512-UHVXGmv9NttI5nWlvXdqxqzbfRebZSmHTT4n5hsUb0uElYXwE71+Zla4/KZjjU96Z6eZPT66OFSVwd2wwBOKyg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    prop-types "15.6.2"
 
 react-inspector@^5.1.0:
   version "5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6186,11 +6186,6 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-cookie@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==
-
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -13548,14 +13543,6 @@ rc@1.2.8, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-cookies@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/react-cookies/-/react-cookies-0.1.1.tgz#2a35807e04f5a13f58ccd1a9fb66574506873c88"
-  integrity sha512-PP75kJ4vtoHuuTdq0TAD3RmlAv7vuDQh9fkC4oDlhntgs9vX1DmREomO0Y1mcQKR9nMZ6/zxoflaMJ3MAmF5KQ==
-  dependencies:
-    cookie "^0.3.1"
-    object-assign "^4.1.1"
 
 react-copy-to-clipboard@^5.0.1:
   version "5.1.0"


### PR DESCRIPTION
This PR removes the following libraries from the project, as they are no longer used and have no references in the codebase:

- react-image
- react-content-loader
- datalist-polyfill
- react-cookies
- strip-ansi