### PR TITLE
refactor: make Hamburger use Icon component

### DIFF
--- a/components/Hamburger/Hamburger.jsx
+++ b/components/Hamburger/Hamburger.jsx
@@ -1,43 +1,28 @@
 import PropTypes from 'prop-types';
-import HamburgerIcon from '@material-ui/icons/Menu';
-import CloseIcon from '@material-ui/icons/Close';
-
 import styled from 'styled-components';
+import BaseIcon from '../Icon';
 import { colors } from '../shared/theme';
 
-const HAMBURGER_SIZE = 24;
-const NOTIFICATION_SIZE = 7;
-
-const getColors = ({ inverted }) => {
-  const weight = !inverted ? 0 : 900;
-
-  return colors.neutral[weight];
-};
-
-const HamburgerWrapper = styled.div`
+const Wrapper = styled.div`
   display: inline-block;
   position: relative;
-  width: ${HAMBURGER_SIZE}px;
-  height: ${HAMBURGER_SIZE}px;
+  width: 24px;
+  height: 24px;
 `;
 
-const NotificationIcon = styled.span`
+const Icon = styled(BaseIcon)`
+  color: ${props => (props.inverted ? colors.neutral[900] : colors.neutral[0])};
+`;
+
+const IconDot = styled.span`
   position: absolute;
-  width: ${NOTIFICATION_SIZE}px;
-  height: ${NOTIFICATION_SIZE}px;
+  width: 7px;
+  height: 7px;
   border: solid 2px ${props => colors.neutral[props.inverted ? 0 : 1000]};
   top: 0;
   right: 0;
-  border-radius: ${NOTIFICATION_SIZE}px;
+  border-radius: 100%;
   background-color: ${colors.error[700]};
-`;
-
-const HamburgerIconWrapper = styled(HamburgerIcon)`
-  color: ${getColors};
-`;
-
-const CloseIconWrapper = styled(CloseIcon)`
-  color: ${getColors};
 `;
 
 const Hamburger = ({
@@ -46,35 +31,26 @@ const Hamburger = ({
   inverted,
   ariaLabelDescription,
 }) => {
-  const HamburgerBlock = (
+  const Block = (
     <>
       {showNotification && (
-        <NotificationIcon
-          aria-label={ariaLabelDescription}
-          inverted={inverted}
-        />
+        <IconDot aria-label={ariaLabelDescription} inverted={inverted} />
       )}
-      <HamburgerIconWrapper inverted={inverted ? 1 : 0} />
+      <Icon name="menu" inverted={inverted} />
     </>
   );
 
   return (
-    <HamburgerWrapper aria-live="polite">
-      {!isOpened ? (
-        HamburgerBlock
-      ) : (
-        <CloseIconWrapper inverted={inverted ? 1 : 0} />
-      )}
-    </HamburgerWrapper>
+    <Wrapper aria-live="polite">
+      {isOpened ? <Icon name="close" inverted={inverted} /> : Block}
+    </Wrapper>
   );
 };
-
-HamburgerWrapper.displayName = 'HamburgerWrapper';
-Hamburger.displayName = 'Hamburger';
 
 Hamburger.propTypes = {
   showNotification: PropTypes.bool,
   isOpened: PropTypes.bool,
+
   /** Swap background and text color */
   inverted: PropTypes.bool,
   ariaLabelDescription: PropTypes.string,

--- a/components/Hamburger/__snapshots__/Hamburger.unit.test.jsx.snap
+++ b/components/Hamburger/__snapshots__/Hamburger.unit.test.jsx.snap
@@ -19,8 +19,9 @@ exports[`<Hamburger /> Should match snapshot with props: default 1`] = `
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c1"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="0"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path
@@ -49,8 +50,9 @@ exports[`<Hamburger /> Should match snapshot with props: inverted 1`] = `
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c1"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="1"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path
@@ -79,8 +81,9 @@ exports[`<Hamburger /> Should match snapshot with props: inverted and isOpened 1
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c1"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="1"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path
@@ -98,6 +101,10 @@ exports[`<Hamburger /> Should match snapshot with props: inverted and showNotifi
   height: 24px;
 }
 
+.c2 {
+  color: #191919;
+}
+
 .c1 {
   position: absolute;
   width: 7px;
@@ -105,12 +112,8 @@ exports[`<Hamburger /> Should match snapshot with props: inverted and showNotifi
   border: solid 2px #ffffff;
   top: 0;
   right: 0;
-  border-radius: 7px;
+  border-radius: 100%;
   background-color: #e91b0c;
-}
-
-.c2 {
-  color: #191919;
 }
 
 <div
@@ -124,8 +127,9 @@ exports[`<Hamburger /> Should match snapshot with props: inverted and showNotifi
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c2"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="1"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path
@@ -154,8 +158,9 @@ exports[`<Hamburger /> Should match snapshot with props: inverted, showNotificat
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c1"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="1"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path
@@ -184,8 +189,9 @@ exports[`<Hamburger /> Should match snapshot with props: isOpened 1`] = `
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c1"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="0"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path
@@ -203,6 +209,10 @@ exports[`<Hamburger /> Should match snapshot with props: showNotification 1`] = 
   height: 24px;
 }
 
+.c2 {
+  color: #ffffff;
+}
+
 .c1 {
   position: absolute;
   width: 7px;
@@ -210,12 +220,8 @@ exports[`<Hamburger /> Should match snapshot with props: showNotification 1`] = 
   border: solid 2px #000000;
   top: 0;
   right: 0;
-  border-radius: 7px;
+  border-radius: 100%;
   background-color: #e91b0c;
-}
-
-.c2 {
-  color: #ffffff;
 }
 
 <div
@@ -229,8 +235,9 @@ exports[`<Hamburger /> Should match snapshot with props: showNotification 1`] = 
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c2"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="0"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path
@@ -259,8 +266,9 @@ exports[`<Hamburger /> Should match snapshot with props: showNotification and is
   <svg
     aria-hidden="true"
     class="MuiSvgIcon-root c1"
+    data-qtm-preloader="icon"
     focusable="false"
-    inverted="0"
+    style="font-size: 24px; max-width: 24px;"
     viewBox="0 0 24 24"
   >
     <path


### PR DESCRIPTION
This PR refactors Hamburger and make it use Icon component instead of import icons directly from @material-ui/icons