### PR TITLE
QTM-485: Adds flash_on icon

### DIFF
--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -87,6 +87,7 @@ import WatchLater from '@material-ui/icons/WatchLater';
 import Whatshot from '@material-ui/icons/Whatshot';
 import Work from '@material-ui/icons/Work';
 import Help from '@material-ui/icons/Help';
+import FlashOn from '@material-ui/icons/FlashOn';
 
 import { theme } from '../shared';
 import icons from '../shared/icons';
@@ -147,6 +148,7 @@ const Icon = ({ name, skin, size, ...props }) => {
     favorite: Favorite,
     favorite_border: FavoriteBorder,
     filter_list: FilterList,
+    flash_on: FlashOn,
     folder: Folder,
     group: Group,
     home: Home,

--- a/components/shared/icons.js
+++ b/components/shared/icons.js
@@ -44,6 +44,7 @@ const icons = [
   'favorite_border',
   'filter_list',
   'folder',
+  'flash_on',
   'group',
   'home',
   'help',


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-485

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [ ] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
- [ ] TypeScript updated

### A11y review
- [ ] A11y checks
  - [ ] accessible via keyboard?
  - [ ] Identifiable through assistive technology (screen-reader chrome extension)?
  - [ ] Semantically correct html elements (or if necessary identified by WAI-ARIA)?
  - [ ] Is there a deficiency in color contrast?

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation