### PR TITLE
Fix hamburguer test

### DIFF
--- a/components/Hamburger/Hamburger.jsx
+++ b/components/Hamburger/Hamburger.jsx
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
 `;
 
 const Icon = styled(BaseIcon).withConfig({
-  shouldForwardProp: prop => prop != 'inverted',
+  shouldForwardProp: prop => prop !== 'inverted',
 })`
   color: ${props => (props.inverted ? colors.neutral[900] : colors.neutral[0])};
 `;

--- a/components/Hamburger/Hamburger.jsx
+++ b/components/Hamburger/Hamburger.jsx
@@ -10,7 +10,9 @@ const Wrapper = styled.div`
   height: 24px;
 `;
 
-const Icon = styled(BaseIcon)`
+const Icon = styled(BaseIcon).withConfig({
+  shouldForwardProp: prop => prop != 'inverted',
+})`
   color: ${props => (props.inverted ? colors.neutral[900] : colors.neutral[0])};
 `;
 


### PR DESCRIPTION
## Description
After merging the pr that refactors the Hamburger component, a warning was identified about passing a non-existent prop to the Icon component. Thus, this pr is based on omitting the passage of the inverted prop to the Icon component and thereby removing the warning of the unit testicles.

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review