### PR TITLE
add support to react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
     "slugify": "^1.3.6"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17",
-    "react-dom": "^16.14.0 || ^17",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "styled-components": ">= 4"
   },
   "lint-staged": {


### PR DESCRIPTION
React 18 has been released for over a year now, and it maintains full backward compatibility. It would be beneficial to allow other projects to utilize the new version.