### PR TITLE
feat(icon): adds more_vert icon

### DIFF
--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -70,7 +70,7 @@ import LockOutlined from '@mui/icons-material/LockOutlined';
 import Markunread from '@mui/icons-material/Markunread';
 import Menu from '@mui/icons-material/Menu';
 import MenuBook from '@mui/icons-material/MenuBook';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import MoreVert from '@mui/icons-material/MoreVert';
 import Notifications from '@mui/icons-material/Notifications';
 import PauseCircleOutline from '@mui/icons-material/PauseCircleOutline';
 import Payment from '@mui/icons-material/Payment';
@@ -194,7 +194,7 @@ const Icon = ({ name, skin, size, ...props }) => {
     markunread: Markunread,
     menu_book: MenuBook,
     menu: Menu,
-    more_vert: MoreVertIcon,
+    more_vert: MoreVert,
     notification: Notifications,
     payment: Payment,
     pause_circle_outline: PauseCircleOutline,

--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -70,6 +70,7 @@ import LockOutlined from '@mui/icons-material/LockOutlined';
 import Markunread from '@mui/icons-material/Markunread';
 import Menu from '@mui/icons-material/Menu';
 import MenuBook from '@mui/icons-material/MenuBook';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Notifications from '@mui/icons-material/Notifications';
 import PauseCircleOutline from '@mui/icons-material/PauseCircleOutline';
 import Payment from '@mui/icons-material/Payment';
@@ -193,6 +194,7 @@ const Icon = ({ name, skin, size, ...props }) => {
     markunread: Markunread,
     menu_book: MenuBook,
     menu: Menu,
+    more_vert: MoreVertIcon,
     notification: Notifications,
     payment: Payment,
     pause_circle_outline: PauseCircleOutline,

--- a/components/shared/icons.js
+++ b/components/shared/icons.js
@@ -68,6 +68,7 @@ const icons = [
   'markunread',
   'menu_book',
   'menu',
+  'more_vert',
   'notification',
   'payment',
   'pause_circle_outline',


### PR DESCRIPTION
## Description
Put the description of the task here.

## Setup
to view the components behavior, run `yarn storybook`

## Review guide
- [x] Coverage (coverage status should not regress)\
      - `yarn test:coverage`
- [x] Unit tests (yarn test:components)
- [x] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
- [ ] TypeScript updated

### A11y review
- [ ] A11y checks
  - [ ] accessible via keyboard?
  - [ ] Identifiable through assistive technology (screen-reader chrome extension)?
  - [ ] Semantically correct html elements (or if necessary identified by WAI-ARIA)?
  - [ ] Is there a deficiency in color contrast?

### Browsers review
- [ ] Layout review
  - [ ] Edge
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari
  - [ ] Mobile
- [ ] Ux review validation