### PR TITLE
feat(Icon.jsx): Added ContactSupport icon

### DIFF
--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -33,6 +33,7 @@ import Clear from '@mui/icons-material/Clear';
 import Close from '@mui/icons-material/Close';
 import Collections from '@mui/icons-material/Collections';
 import ContactPhone from '@mui/icons-material/ContactPhone';
+import ContactSupport from '@mui/icons-material/ContactSupport';
 import Contacts from '@mui/icons-material/Contacts';
 import Contrast from '@mui/icons-material/Contrast';
 import CreditCard from '@mui/icons-material/CreditCard';
@@ -158,6 +159,7 @@ const Icon = ({ name, skin, size, ...props }) => {
     collections: Collections,
     contacts: Contacts,
     contact_phone: ContactPhone,
+    contact_support: ContactSupport,
     contrast: Contrast,
     credit_card: CreditCard,
     date_range: DateRange,

--- a/components/Icon/index.d.ts
+++ b/components/Icon/index.d.ts
@@ -189,6 +189,7 @@ export type IconNames =
     | 'confirmation_number'
     | 'contact_mail'
     | 'contact_phone'
+    | 'contact_support'
     | 'contacts'
     | 'content_copy'
     | 'content_cut'

--- a/components/shared/icons.js
+++ b/components/shared/icons.js
@@ -32,6 +32,7 @@ const icons = [
   'collections',
   'contacts',
   'contact_phone',
+  'contact_support',
   'contrast',
   'credit_card',
   'date_range',


### PR DESCRIPTION
Icon used in https://github.com/catho/help_help-center_app. Currently the application uses this icon directly from the @material-ui/icons lib, which has a dependency on the @material-ui/core lib. The latter was not added to the project as it is used directly from the version of quantum currently installed in the application. As the latest version of quantum no longer contains the @material-ui/core lib, the application breaks when updating the quantum version. By adding this icon here, the application works again

## Review guide
- [ ] Code review
- [ ] Doc
- [ ] TypeScript updated
