### PR TITLE
fix(AutoComplete.jsx): Preventing auto complete from set a suggestion…

### DIFF
--- a/components/AutoComplete/AutoComplete.jsx
+++ b/components/AutoComplete/AutoComplete.jsx
@@ -17,6 +17,7 @@ import useKeyPress from './SubComponents/UseKeyPress';
 const ITEM_HEIGHT = '44px';
 const MAX_ITEMS_VISIBILITY = 7;
 const DROPITEM_FONT_SIZE = baseFontSize * 0.875;
+const NON_FOCUSABLE_SUGGESTION_INDEX = -1;
 
 const ComponentWrapper = styled.div`
   ${({
@@ -167,7 +168,7 @@ const AutoComplete = ({
     filterSuggestions.length,
   );
   const [showSuggestions, setShowSuggestions] = useState(false);
-  const [cursor, setCursor] = useState(-1);
+  const [cursor, setCursor] = useState(NON_FOCUSABLE_SUGGESTION_INDEX);
   const wrapperRef = useRef();
   const listOptions = useRef();
   const autoInputRef = useRef(null);
@@ -182,7 +183,7 @@ const AutoComplete = ({
     const input = wrapperRef.current?.children[1];
     if (input) {
       input.focus();
-      setCursor(-1);
+      setCursor(NON_FOCUSABLE_SUGGESTION_INDEX);
     }
   };
 
@@ -190,7 +191,10 @@ const AutoComplete = ({
     suggestions.filter((suggestion) => {
       let option = normalizeChars(suggestion.toLowerCase());
       option = normalizeChars(option);
-      return option.indexOf(normalizeChars(currentValue.toLowerCase())) > -1;
+      return (
+        option.indexOf(normalizeChars(currentValue.toLowerCase())) >
+        NON_FOCUSABLE_SUGGESTION_INDEX
+      );
     });
 
   const handleFilter = (currentValue) => {
@@ -202,7 +206,7 @@ const AutoComplete = ({
   const handleChange = (currentValue) => {
     setUserTypedValue(currentValue);
     onChange(currentValue);
-    setCursor(-1);
+    setCursor(NON_FOCUSABLE_SUGGESTION_INDEX);
     handleFilter(currentValue);
   };
 
@@ -228,7 +232,7 @@ const AutoComplete = ({
     setUserTypedValue('');
     onChange('');
     setFilterSuggestions(suggestions);
-    setCursor(-1);
+    setCursor(NON_FOCUSABLE_SUGGESTION_INDEX);
   };
 
   const handleEscPress = ({ key }) => {
@@ -313,11 +317,11 @@ const AutoComplete = ({
 
   /* istanbul ignore next */
   useEffect(() => {
-    if (showSuggestions && tabPress) {
-      setUserTypedValue(filterSuggestions[cursor]);
-      onSelectedItem(filterSuggestions[cursor]);
-      setShowSuggestions(false);
-    } else if (tabPress) {
+    if (tabPress) {
+      if (showSuggestions && cursor !== NON_FOCUSABLE_SUGGESTION_INDEX) {
+        setUserTypedValue(filterSuggestions[cursor]);
+        onSelectedItem(filterSuggestions[cursor]);
+      }
       setShowSuggestions(false);
     }
   }, [tabPress]);


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-775

## Review guide
- [ ] Code review
- [ ] Build (https://github.com/catho/recruiter-experience_company-registration_app)

## How to test

- Run the storybook and select the AutoComplete component
- Inspect the page and select the Console tab
- Type the text "Moran" and wait for the list of suggestions to open, but do not select any item.
- Press the "Tab" key to change the input focus.
- Now press "Shift + Tab" to return focus to the input (When returning focus to the input, the text must be selected)
- Now click on the input with the mouse.
- If no warnings are displayed in the console, then the fixes worked. 

Note: Following this step by step, in the master branch, several warnings are triggered in the console.

## How to test in the application

- On quantum, run `yarn && yarn build`
- Now clone the project https://github.com/catho/recruiter-experience_company-registration_app. (ENVs sent via Secure Password (https://ssaws.catho.vs/). Go to the "My Safe" page => "Passwords" and search for "ENV Recruiter Experience Company Registration"
)
- Add the local quandum build to the cloned project using the `yarn add ../quantum/dist` command
- Run the application using `yarn dev`
- On the opened page, focus on AutoComplete just by using the Tab key.
- In autocomplete, type "Develop", wait for the list of suggestions to open, but do not select any option. 
- Now press "Tab". If the application doesn't crash, the fix worked.
