### PR TITLE
feat(QTM-786): 

### DIFF
--- a/components/DropdownLight/DropdownLight.jsx
+++ b/components/DropdownLight/DropdownLight.jsx
@@ -330,6 +330,7 @@ const DropdownLight = ({
           required={required}
         />
         <Button
+          type="button"
           aria-haspopup="true"
           aria-label={isOpen ? 'fechar lista de itens' : 'abrir lista de itens'}
           onClick={handleToggleDropdown}

--- a/components/DropdownLight/__snapshots__/DropdownLight.unit.test.jsx.snap
+++ b/components/DropdownLight/__snapshots__/DropdownLight.unit.test.jsx.snap
@@ -147,6 +147,7 @@ exports[`<DropdownLight /> should match the snapshots 1`] = `
         aria-label="abrir lista de itens"
         class="c4"
         id=""
+        type="button"
       >
         Select an option
         <svg
@@ -315,6 +316,7 @@ exports[`<DropdownLight /> should match the snapshots 2`] = `
         aria-label="abrir lista de itens"
         class="c4"
         id=""
+        type="button"
       >
         Select an option
         <svg
@@ -506,6 +508,7 @@ exports[`<DropdownLight /> should match the snapshots 3`] = `
         aria-label="abrir lista de itens"
         class="c6"
         id=""
+        type="button"
       >
         Select an option
         <svg
@@ -685,6 +688,7 @@ exports[`<DropdownLight /> should match the snapshots 4`] = `
         aria-label="abrir lista de itens"
         class="c4"
         id=""
+        type="button"
       >
         Select an option
         <svg
@@ -873,6 +877,7 @@ exports[`<DropdownLight /> should match the snapshots 5`] = `
         aria-label="abrir lista de itens"
         class="c4"
         id=""
+        type="button"
       >
         Select an option
         <svg
@@ -1046,6 +1051,7 @@ exports[`<DropdownLight /> should match the snapshots 6`] = `
         aria-label="abrir lista de itens"
         class="c4"
         id=""
+        type="button"
       >
         this is a input placeholder
         <svg
@@ -1215,6 +1221,7 @@ exports[`<DropdownLight /> should match the snapshots 7`] = `
         class="c4"
         disabled=""
         id=""
+        type="button"
       >
         Select an option
         <svg
@@ -1383,6 +1390,7 @@ exports[`<DropdownLight /> should match the snapshots 8`] = `
         aria-label="abrir lista de itens"
         class="c4"
         id=""
+        type="button"
       >
         Select an option
         <svg


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-786

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Code review

## How to test

- Clone quantum
- Edit the stories/DropdownLight/DropdownLight.regrssion-test.story.jsx file
- Replace the Template constant with:
`const Template = (args) => {
  const handleOnSubmit = (e) => {
    e.preventDefault();
    console.log("Form sent");
  }
  return <form onSubmit={handleOnSubmit}><DropdownLight items={itemsObjectMock} {...args} /></form>
};`. The idea is that when selecting an item from DropdownLight, no form submission is triggered.

- Run `yarn test:regression:storybook`
- In the browser, access http://localhost:9006/ and look for the DropdownLight/Default tests.
- Now select an item and see if the form is triggered. If true, the component is still having problems.