### PR TITLE
feat(QTM-728): Migrated to css modules and updated types and snapshots

### DIFF
--- a/components/AutoComplete/AutoComplete.jsx
+++ b/components/AutoComplete/AutoComplete.jsx
@@ -1,8 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
-import { shadow, normalizeChars } from '../shared';
-import { baseFontSize, colors, spacing } from '../shared/theme';
+import classNames from 'classnames';
+import { normalizeChars } from '../shared';
 import Icon from '../Icon';
 
 import {
@@ -13,139 +12,9 @@ import {
   RequiredMark,
 } from '../Input/sub-components';
 import useKeyPress from './SubComponents/UseKeyPress';
+import styles from './AutoComplete.module.css';
 
-const ITEM_HEIGHT = '44px';
-const MAX_ITEMS_VISIBILITY = 7;
-const DROPITEM_FONT_SIZE = baseFontSize * 0.875;
 const NON_FOCUSABLE_SUGGESTION_INDEX = -1;
-
-const ComponentWrapper = styled.div`
-  ${({
-    theme: {
-      colors: { neutral },
-    },
-    skin = 'default',
-  }) => css`
-    position: relative;
-    color: ${skin === 'default' ? neutral[700] : neutral[0]};
-  `}
-`;
-
-const InputWrapper = styled.div`
-  position: relative;
-`;
-
-const propsNotContainedInTextInput = ['theme'];
-
-const InputText = styled(TextInput).withConfig({
-  shouldForwardProp: (prop) => !propsNotContainedInTextInput.includes(prop),
-})`
-  ${({
-    theme: {
-      spacing: { xsmall },
-    },
-  }) => css`
-    margin-top: ${xsmall}px;
-  `}
-`;
-
-const InputIcon = styled(Icon)`
-  cursor: pointer;
-  position: absolute;
-  ${({
-    theme: {
-      spacing: { xsmall, medium },
-    },
-  }) => css`
-    right: ${medium}px;
-    bottom: ${xsmall * 1.25}px;
-    width: ${baseFontSize * 1.5}px;
-  `}
-`;
-
-const InputErrorIcon = styled(InputIcon).attrs({ name: 'error' })`
-  ${({
-    theme: {
-      colors: {
-        error: { 700: error700 },
-      },
-    },
-    skin,
-  }) => css`
-    color: ${skin === 'default' ? error700 : 'inherit'};
-  `}
-`;
-
-const List = styled.ul`
-  border-radius: 4px;
-  box-sizing: border-box;
-  list-style: none;
-  max-height: calc(${ITEM_HEIGHT} * ${MAX_ITEMS_VISIBILITY});
-  overflow: auto;
-  padding: 0;
-  position: absolute;
-  width: 100%;
-  z-index: 1;
-
-  ${({ theme }) => {
-    const {
-      spacing: { xxsmall },
-      colors: {
-        neutral: { 0: neutral0, 700: neutral700 },
-      },
-    } = theme;
-    return css`
-      background-color: ${neutral0};
-      margin-top: ${xxsmall}px;
-      ${shadow(3, neutral700)({ theme })};
-    `;
-  }}
-`;
-
-const ListItem = styled.li`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  box-sizing: border-box;
-  cursor: pointer;
-  height: ${ITEM_HEIGHT};
-  ${({
-    theme: {
-      spacing: { xsmall, medium },
-      colors: {
-        neutral: { 0: neutral0, 700: neutral700 },
-      },
-    },
-  }) => css`
-    color: ${neutral700};
-    font-size: ${DROPITEM_FONT_SIZE}px;
-    background-color: ${neutral0};
-    padding: ${xsmall}px ${medium}px;
-  `}
-
-  &[aria-selected = 'true' ], &:hover {
-    ${({
-      theme: {
-        colors: {
-          neutral: { 100: neutral100 },
-        },
-      },
-    }) => css`
-      background-color: ${neutral100};
-    `}
-  }
-`;
-
-const PoliteStatus = styled.div`
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-`;
 
 const AutoComplete = ({
   id = '',
@@ -157,15 +26,25 @@ const AutoComplete = ({
   helperText = '',
   placeholder = 'Select an option',
   suggestions,
-  theme = {
-    spacing,
-    colors,
-  },
   onSelectedItem = () => {},
   onChange = () => {},
   required = false,
   skin = 'default',
 }) => {
+  const wrapperClass = classNames(styles.wrapper, {
+    [styles['wrapper-dark']]: skin === 'dark',
+  });
+  const inputWrapperClass = classNames(styles['input-wrapper']);
+  const inputTextClass = classNames(styles['input-text']);
+  const inputIconClass = classNames(styles['input-icon']);
+  const inputErrorIconClass = classNames(
+    styles['input-icon'],
+    styles[`input-error-icon-${skin}`],
+  );
+  const listClass = classNames(styles['list-suggestions'], 'shadow-3');
+  const itemClass = classNames(styles['item-suggestions']);
+  const politeClass = classNames(styles['polite-status']);
+
   const [userTypedValue, setUserTypedValue] = useState(value);
   const [filterSuggestions, setFilterSuggestions] = useState(suggestions);
   const [filterSuggestionsLength, setFilterSuggestionsLength] = useState(
@@ -248,27 +127,27 @@ const AutoComplete = ({
 
   const generateSuggestions = () =>
     showSuggestions && filterSuggestions ? (
-      <List
-        theme={theme}
+      <ul
         role="listbox"
         id="autocompleteOptions"
         ref={listOptions}
-        skin={skin}
+        className={listClass}
       >
         {filterSuggestions.map((item, index) => (
-          <ListItem
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+          <li
             key={item}
             aria-posinset={index}
             onClick={() => handleItemClick(item)}
-            theme={theme}
+            className={itemClass}
             aria-selected={index === cursor}
             role="option"
             tabIndex="-1"
           >
             {item}
-          </ListItem>
+          </li>
         ))}
-      </List>
+      </ul>
     ) : null;
 
   const generateAssistiveDescript = () => {
@@ -346,13 +225,13 @@ const AutoComplete = ({
   }, [suggestions]);
 
   return (
-    <ComponentWrapper theme={theme} skin={skin}>
-      <InputWrapper ref={wrapperRef}>
+    <div className={wrapperClass}>
+      <div className={inputWrapperClass} ref={wrapperRef}>
         <InputLabel htmlFor={id}>
           {label}
           {required && <RequiredMark skin={skin}>*</RequiredMark>}
         </InputLabel>
-        <InputText
+        <TextInput
           id={id}
           ref={autoInputRef}
           name={name}
@@ -370,39 +249,40 @@ const AutoComplete = ({
           onChange={(e) => handleChange(e.target.value)}
           skin={skin}
           required={required}
-          theme={theme}
+          className={inputTextClass}
         />
         {userTypedValue && !error && !disabled && (
-          <InputIcon
-            theme={theme}
+          <Icon
             name="clear"
             description="limpar valor"
             onClick={() => handleClearValue()}
+            className={inputIconClass}
           />
         )}
         {generateSuggestions()}
         {error && (
-          <InputErrorIcon description={error} theme={theme} skin={skin} />
+          <Icon
+            name="error"
+            description={error}
+            className={inputErrorIconClass}
+          />
         )}
-      </InputWrapper>
+      </div>
       {helperText && <HelperText>{helperText}</HelperText>}
-      {error && (
-        <InputErrorMessage theme={theme} skin={skin}>
-          {error}
-        </InputErrorMessage>
-      )}
-      <PoliteStatus role="status" aria-atomic="true" aria-live="polite">
+      {error && <InputErrorMessage skin={skin}>{error}</InputErrorMessage>}
+      <div
+        role="status"
+        aria-atomic="true"
+        aria-live="polite"
+        className={politeClass}
+      >
         {generateAssistiveDescript()}
-      </PoliteStatus>
-    </ComponentWrapper>
+      </div>
+    </div>
   );
 };
 
 AutoComplete.propTypes = {
-  theme: PropTypes.shape({
-    colors: PropTypes.object,
-    spacing: PropTypes.object,
-  }),
   /** A list of string or objects with the values to show in component */
   suggestions: PropTypes.arrayOf(PropTypes.string).isRequired,
   id: PropTypes.string,

--- a/components/AutoComplete/AutoComplete.module.css
+++ b/components/AutoComplete/AutoComplete.module.css
@@ -1,0 +1,81 @@
+:root {
+    --max-items-visibility: 7;
+    --item-height: 44px;
+    --dropitem-font-size: calc(var(--qtm-base-font-size) * 0.875);
+}
+
+.wrapper {
+    position: relative;
+    color: var(--qtm-colors-neutral-700);
+}
+
+.input-wrapper {
+    position: relative;
+}
+
+.wrapper-dark {
+    color: var(--qtm-colors-neutral-0);
+}
+
+.input-text {
+    margin-top: var(--qtm-spacing-xsmall);
+}
+
+.input-icon {
+    cursor: pointer;
+    position: absolute;
+    right: var(--qtm-spacing-medium);
+    bottom: calc(var(--qtm-spacing-xsmall) * 1.25);
+    width: calc(var(--qtm-base-font-size) * 1.5);
+}
+
+.input-error-icon-default {
+    color: var(--qtm-colors-error-700);
+}
+
+.input-error-icon-dark {
+    color: inherit;
+}
+
+.polite-status {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+
+.list-suggestions {
+    border-radius: 4px;
+    box-sizing: border-box;
+    list-style: none;
+    max-height: calc(var(--item-height) * var(--max-items-visibility));
+    overflow: auto;
+    padding: 0;
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+    background-color: var(--qtm-colors-neutral-0);
+    margin-top: var(--qtm-spacing-xxsmall);
+}
+
+.item-suggestions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    box-sizing: border-box;
+    cursor: pointer;
+    height: var(--item-height);
+    color: var(--qtm-colors-neutral-700);
+    font-size: var(--dropitem-font-size);
+    background-color: var(--qtm-colors-neutral-0);
+    padding: var(--qtm-spacing-xsmall) var(--qtm-spacing-medium);
+}
+
+.item-suggestions[aria-selected='true'],
+.item-suggestions:hover {
+    background-color: var(--qtm-colors-neutral-100);
+}

--- a/components/AutoComplete/__snapshots__/AutoComplete.unit.test.jsx.snap
+++ b/components/AutoComplete/__snapshots__/AutoComplete.unit.test.jsx.snap
@@ -24,22 +24,21 @@ exports[`AutoComplete Should render Autocomplete 1`] = `
   width: 100%;
 }
 
-.c0 {
+.AutoComplete-module__wrapper___0v99I {
+  color: var(--qtm-colors-neutral-700);
+}
+
+.AutoComplete-module__input-wrapper___Yz9qd,
+.AutoComplete-module__wrapper___0v99I {
   position: relative;
-  color: #424242;
 }
 
-.c1 {
-  position: relative;
+.AutoComplete-module__input-text___8DYxo {
+  margin-top: var(--qtm-spacing-xsmall);
 }
 
-.c2 {
-  margin-top: 8px;
-}
-
-.c3 {
+.AutoComplete-module__polite-status___DWMsJ {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -50,10 +49,10 @@ exports[`AutoComplete Should render Autocomplete 1`] = `
 }
 
 <div
-  class="c0"
+  class="AutoComplete-module__wrapper___0v99I"
 >
   <div
-    class="c1"
+    class="AutoComplete-module__input-wrapper___Yz9qd"
   >
     <label
       class="InputLabel-module__input-label___u-ovg"
@@ -64,7 +63,7 @@ exports[`AutoComplete Should render Autocomplete 1`] = `
       aria-expanded="false"
       aria-owns="autocompleteOptions"
       autocomplete="off"
-      class="TextInput-module__text-input___VCylJ c2"
+      class="TextInput-module__text-input___VCylJ AutoComplete-module__input-text___8DYxo"
       id=""
       name=""
       placeholder="Select an option"
@@ -77,7 +76,7 @@ exports[`AutoComplete Should render Autocomplete 1`] = `
   <div
     aria-atomic="true"
     aria-live="polite"
-    class="c3"
+    class="AutoComplete-module__polite-status___DWMsJ"
     role="status"
   >
     Digite uma ou mais letras para expandir os resultados. 5 estão disponiveis.
@@ -115,22 +114,25 @@ exports[`AutoComplete Should render Autocomplete with dark skin 1`] = `
   color: var(--qtm-colors-neutral-0);
 }
 
-.c0 {
+.AutoComplete-module__wrapper___0v99I {
+  color: var(--qtm-colors-neutral-700);
+}
+
+.AutoComplete-module__input-wrapper___Yz9qd,
+.AutoComplete-module__wrapper___0v99I {
   position: relative;
-  color: #ffffff;
 }
 
-.c1 {
-  position: relative;
+.AutoComplete-module__wrapper-dark___PndN8 {
+  color: var(--qtm-colors-neutral-0);
 }
 
-.c2 {
-  margin-top: 8px;
+.AutoComplete-module__input-text___8DYxo {
+  margin-top: var(--qtm-spacing-xsmall);
 }
 
-.c3 {
+.AutoComplete-module__polite-status___DWMsJ {
   border: 0;
-  -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
@@ -141,10 +143,10 @@ exports[`AutoComplete Should render Autocomplete with dark skin 1`] = `
 }
 
 <div
-  class="c0"
+  class="AutoComplete-module__wrapper___0v99I AutoComplete-module__wrapper-dark___PndN8"
 >
   <div
-    class="c1"
+    class="AutoComplete-module__input-wrapper___Yz9qd"
   >
     <label
       class="InputLabel-module__input-label___u-ovg"
@@ -155,7 +157,7 @@ exports[`AutoComplete Should render Autocomplete with dark skin 1`] = `
       aria-expanded="false"
       aria-owns="autocompleteOptions"
       autocomplete="off"
-      class="TextInput-module__text-input___VCylJ TextInput-module__text-input-dark___TrWzt c2"
+      class="TextInput-module__text-input___VCylJ TextInput-module__text-input-dark___TrWzt AutoComplete-module__input-text___8DYxo"
       id=""
       name=""
       placeholder="Select an option"
@@ -168,7 +170,7 @@ exports[`AutoComplete Should render Autocomplete with dark skin 1`] = `
   <div
     aria-atomic="true"
     aria-live="polite"
-    class="c3"
+    class="AutoComplete-module__polite-status___DWMsJ"
     role="status"
   >
     Digite uma ou mais letras para expandir os resultados. 5 estão disponiveis.

--- a/components/AutoComplete/index.css
+++ b/components/AutoComplete/index.css
@@ -1,0 +1,1 @@
+@import './AutoComplete.module.css';

--- a/components/AutoComplete/index.d.ts
+++ b/components/AutoComplete/index.d.ts
@@ -1,9 +1,5 @@
 import { FC } from 'react';
 export interface AutoCompleteProps {
-  theme?: {
-    colors?: object;
-    spacing?: object;
-  };
   suggestions: Array<string>;
   id?: string;
   name?: string;

--- a/components/index.css
+++ b/components/index.css
@@ -20,3 +20,4 @@
 @import "./shared/index.css";
 @import "./SegmentedControl/index.css";
 @import "./Input/index.css";
+@import "./AutoComplete/index.css";


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-728

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Regression \
      - first start the storybook for regression tests(and keep it open): ` yarn test:regression:storybook`; \
      - then run the regression tests: `yarn test:regression`
- [ ] Code review
- [ ] TypeScript updated
- [ ] Build

### How to test build

- In quantum, install the dependencies and build, running `yarn && yarn build`
- Clone the repository https://github.com/catho/ssr-quantum-simulator
- In ssr-quantum-simulator, add the local quantum build using `yarn add [local-path]/quantum/dist`
- Change the GlobalStyle imports to Typography in the _app and quantum.js files.
- In the _app file, import the quantum css using `import '@catho/quantum/index.css'`
- Still in ssr-quantum-simulator, run `yarn dev` and access the page http://localhost:3000/quantum
- Compare components with https://catho.github.io/quantum/?path=/docs/introduction-gettingstarted--docs

### How to test visual changes
- In quantum, install the dependencies and build, running `yarn && yarn storybook`
- Access https://catho.github.io/quantum/?path=/docs/introduction-gettingstarted--docs and http://localhost:9007/, in parallel, and make visual comparisons of the components affected by the changes. 

Note: 
- It is important to check states (hover, focus, disabled, etc.), as they are not valid for regressive tests (yarn test:regression)