### PR TITLE
docs(Alert.mdx): Removing onClose from component usage examples and a…

### DIFF
--- a/stories/Alert/Alert.mdx
+++ b/stories/Alert/Alert.mdx
@@ -9,7 +9,8 @@ import {
   Primary,
   Success,
   Error,
-  WithIcon
+  WithIcon,
+  WithClose
 } from './Alert.stories.jsx';
 
 import EvaluationForm from '../../stories/shared/EvaluationForm'
@@ -63,6 +64,12 @@ import Alert from '@catho/quantum/Alert';
 
 <Canvas>
   <Story of={WithIcon} />
+</Canvas>
+
+### With Close
+
+<Canvas>
+  <Story of={WithClose} />
 </Canvas>
 
 <EvaluationForm componentName="Alert" />

--- a/stories/Alert/Alert.stories.jsx
+++ b/stories/Alert/Alert.stories.jsx
@@ -16,11 +16,7 @@ const sampleChildren = (
   </span>
 );
 
-const Template = (args) => (
-  <Alert onClose={() => {}} {...args}>
-    {sampleChildren}
-  </Alert>
-);
+const Template = (args) => <Alert {...args}>{sampleChildren}</Alert>;
 
 export const Default = Template.bind({});
 
@@ -43,4 +39,10 @@ export const WithIcon = Template.bind({});
 WithIcon.args = {
   skin: 'primary',
   icon: 'info',
+};
+
+export const WithClose = Template.bind({});
+WithClose.args = {
+  skin: 'primary',
+  onClose: () => {},
 };


### PR DESCRIPTION
…dding component-specific exampl

## Description
https://jirasoftware.catho.com.br/browse/QTM-784

## Review guide
- [ ] Doc (yarn storybook)
- [ ] Code review

## Note
When the onClose prop is not passed, the close button is not displayed. Therefore, we do not need to implement this feature. I believe that this task was created because in the doc the close button is always visible, as an onClose function is passed to all usage examples, not making it clear that the prop is optional. I'm just going to update the doc, adding an example of specific use of the Alert component with the option to show the close button, and from the other examples remove the onClose prop so as not to display the button.