### PR TITLE
fix(QTM-402): Correction in the display of emoji instead of the balloon position indicator arrow

### DIFF
--- a/components/Popover/__snapshots__/Popover.unit.test.jsx.snap
+++ b/components/Popover/__snapshots__/Popover.unit.test.jsx.snap
@@ -117,7 +117,7 @@ exports[`Popover component should match snapshots 1`] = `
   color: #ffffff;
   font-size: 16px;
   position: absolute;
-  content: '▼';
+  content: '▼︎';
   left: 50%;
   text-shadow: 0px 8px 4px rgba(66,66,66,0.2);
   bottom: 0;
@@ -314,7 +314,7 @@ exports[`Popover component should match snapshots 2`] = `
   color: #ffffff;
   font-size: 16px;
   position: absolute;
-  content: '▼';
+  content: '▼︎';
   left: 50%;
   text-shadow: 0px 8px 4px rgba(66,66,66,0.2);
   bottom: 0;
@@ -515,7 +515,7 @@ exports[`Popover component should match snapshots 3`] = `
   color: #dcedc8;
   font-size: 16px;
   position: absolute;
-  content: '▼';
+  content: '▼︎';
   left: 50%;
   text-shadow: 0px 8px 4px rgba(66,66,66,0.2);
   bottom: 0;
@@ -720,7 +720,7 @@ exports[`Popover component should match snapshots 4`] = `
   color: #ffefd6;
   font-size: 16px;
   position: absolute;
-  content: '▼';
+  content: '▼︎';
   left: 50%;
   text-shadow: 0px 8px 4px rgba(66,66,66,0.2);
   bottom: 0;
@@ -929,7 +929,7 @@ exports[`Popover component should match snapshots 5`] = `
   color: #fff5f5;
   font-size: 16px;
   position: absolute;
-  content: '▼';
+  content: '▼︎';
   left: 50%;
   text-shadow: 0px 8px 4px rgba(66,66,66,0.2);
   bottom: 0;
@@ -1139,7 +1139,7 @@ exports[`Popover component should match snapshots 6`] = `
   font-size: 16px;
   position: absolute;
   top: -4px;
-  content: '▲';
+  content: '▲︎';
   left: 50%;
   text-shadow: 0px -3px 4px rgba(66,66,66,0.2);
   -webkit-transform: translateX(-50%);
@@ -1348,7 +1348,7 @@ exports[`Popover component should match snapshots 7`] = `
   font-size: 16px;
   position: absolute;
   bottom: 50%;
-  content: '▶';
+  content: '▶︎';
   right: -8px;
   text-shadow: 4px 1px 4px rgba(66,66,66,0.2);
 }
@@ -1554,7 +1554,7 @@ exports[`Popover component should match snapshots 8`] = `
   font-size: 16px;
   position: absolute;
   bottom: 50%;
-  content: '◀';
+  content: '◀︎';
   left: -8px;
   text-shadow: -4px 1px 4px rgba(66,66,66,0.2);
 }
@@ -1759,7 +1759,7 @@ exports[`Popover component should match snapshots 9`] = `
   color: #424242;
   font-size: 16px;
   position: absolute;
-  content: '▼';
+  content: '▼︎';
   left: 50%;
   text-shadow: 0px 8px 4px rgba(66,66,66,0.2);
   bottom: 0;

--- a/components/Popover/arrowProperties.js
+++ b/components/Popover/arrowProperties.js
@@ -6,7 +6,7 @@ const CENTER_POSITION = '50%';
 
 const placementPosition = ({ neutral: { 700: shadowColor } }) => ({
   top: `
-    content: '▼';
+    content: '\u25BC\uFE0E';
     left: ${CENTER_POSITION};
     text-shadow: 0px 8px 4px ${hexToRgba(shadowColor, 0.2)};
     bottom: 0;
@@ -14,20 +14,20 @@ const placementPosition = ({ neutral: { 700: shadowColor } }) => ({
   `,
   bottom: `
     top: -4px;
-    content: '▲';
+    content: '\u25B2\uFE0E';
     left: ${CENTER_POSITION};
     text-shadow: 0px -3px 4px ${hexToRgba(shadowColor, 0.2)};
     transform: translateX(-${CENTER_POSITION});
   `,
   right: `
     bottom: ${CENTER_POSITION};
-    content: '◀';
+    content: '\u25C0\uFE0E';
     left: ${SIDE_POSITION_X}px;
     text-shadow: -4px 1px 4px ${hexToRgba(shadowColor, 0.2)};
   `,
   left: `
     bottom: ${CENTER_POSITION};
-    content: '▶';
+    content: '\u25B6\uFE0E';
     right: ${SIDE_POSITION_X}px;
     text-shadow: 4px 1px 4px ${hexToRgba(shadowColor, 0.2)};
   `,


### PR DESCRIPTION
## Description
https://jirasoftware.catho.com.br/browse/QTM-402

## Review guide
- [ ] Unit tests (yarn test:components)
- [ ] Regression
- [ ] Code review


## About the solution
The character was changed to its unicode (Ex: "25C0"). In some contexts, unicode must come after "\u", as this is a unicode code indicator. After the character unicode, a unicode variation "\uFE0E" was added, which forces rendering as text instead of emoji. the end result is \u25C0\uFE0E