### PR TITLE
ci: using NPM_TOKEN_WRITE instead NPM_TOKEN

### DIFF
--- a/.github/workflows/actions-publish.yml
+++ b/.github/workflows/actions-publish.yml
@@ -48,12 +48,12 @@ jobs:
       - name: Setting NPM token
         run: ./scripts/publish.sh
         env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{secrets.NPM_TOKEN_WRITE}}
 
       - name: Publish package
         run: yarn semantic-release
         env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{secrets.NPM_TOKEN_WRITE}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_URL: 'https://api.github.com/'
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing packages. The main change is to use a more appropriately scoped NPM token for publishing steps.

- Workflow improvements:
  * [`.github/workflows/actions-publish.yml`](diffhunk://#diff-d1eee0950f1d1cddd2a218b26ea795016680405d5ffa8cad1d393bccb7b62a69L51-R56): Updated the `NPM_TOKEN` environment variable to use `secrets.NPM_TOKEN_WRITE` instead of `secrets.NPM_TOKEN` in both the `publish.sh` script and the `semantic-release` step, ensuring that only a write-scoped token is used for publishing.